### PR TITLE
change default value of PRIMITIV_BUILD_TESTS to OFF from ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(primitiv VERSION 0.1.0 LANGUAGES CXX)
 set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
 option(PRIMITIV_BUILD_STATIC_LIBRARY "Builds static library." OFF)
-option(PRIMITIV_BUILD_TESTS "Builds test binaries." ON)
+option(PRIMITIV_BUILD_TESTS "Builds test binaries." OFF)
 option(PRIMITIV_USE_CACHE "Enables cached values in some functions but needs more memory." OFF)
 option(PRIMITIV_USE_CUDA "Finds CUDA library ant use it." OFF)
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Building Options
 
 - `PRIMITIV_BUILD_STATIC_LIBRARY` (default=`OFF`)
   - Builds a static library instead of a shared object.
-- `PRIMITIV_BUILD_TESTS` (default=`ON`)
+- `PRIMITIV_BUILD_TESTS` (default=`OFF`)
   - Builds test binaries and generates `make test` command.
 - `PRIMITIV_USE_CACHE` (default=`OFF`)
   - Whether or not to use cached values to prevent increasing computation amount.


### PR DESCRIPTION
PRIMITIV_BUILD_TESTS may be better if the default value is OFF rather than ON.
This is because of Google Test dependency, installation should be easy.