### PR TITLE
Remove static Trainer::load() functions and Trainer names.

### DIFF
--- a/examples/encdec/encdec.cc
+++ b/examples/encdec/encdec.cc
@@ -32,7 +32,7 @@
 #include <random>
 
 #include <primitiv/primitiv.h>
-#include <primitiv/primitiv_cuda.h>
+//#include <primitiv/primitiv_cuda.h>
 
 #include "lstm.h"
 #include "utils.h"
@@ -309,7 +309,8 @@ int main(const int argc, const char *argv[]) {
   }
 
   cerr << "initializing device ... " << flush;
-  devices::CUDA dev(0);
+  devices::Naive dev;
+  //devices::CUDA dev(0);
   Device::set_default(dev);
   cerr << "done." << endl;
 
@@ -324,10 +325,11 @@ int main(const int argc, const char *argv[]) {
   } else if (mode == "resume") {
     cerr << "loading model/trainer ... " << flush;
     ::EncoderDecoder<Node> encdec("encdec", prefix + '.');
-    shared_ptr<Trainer> trainer = Trainer::load(prefix + ".trainer.config");
+    trainers::Adam trainer;
+    trainer.load(prefix + ".trainer.config");
     float valid_ppl = ::load_ppl(prefix + ".valid_ppl.config");
     cerr << "done." << endl;
-    ::train(encdec, *trainer, prefix, valid_ppl);
+    ::train(encdec, trainer, prefix, valid_ppl);
   } else {  // mode == "test"
     cerr << "loading model ... ";
     ::EncoderDecoder<Tensor> encdec("encdec", prefix + '.');

--- a/examples/encdec/encdec_attention.cc
+++ b/examples/encdec/encdec_attention.cc
@@ -36,7 +36,7 @@
 #include <random>
 
 #include <primitiv/primitiv.h>
-#include <primitiv/primitiv_cuda.h>
+//#include <primitiv/primitiv_cuda.h>
 
 #include "lstm.h"
 #include "utils.h"
@@ -365,7 +365,8 @@ int main(const int argc, const char *argv[]) {
   }
 
   cerr << "initializing device ... " << flush;
-  devices::CUDA dev(0);
+  devices::Naive dev;
+  //devices::CUDA dev(0);
   Device::set_default(dev);
   cerr << "done." << endl;
 
@@ -380,10 +381,11 @@ int main(const int argc, const char *argv[]) {
   } else if (mode == "resume") {
     cerr << "loading model/trainer ... " << flush;
     ::EncoderDecoder<Node> encdec("encdec", prefix + '.');
-    shared_ptr<Trainer> trainer = Trainer::load(prefix + ".trainer.config");
+    trainers::Adam trainer;
+    trainer.load(prefix + ".trainer.config");
     float valid_ppl = ::load_ppl(prefix + ".valid_ppl.config");
     cerr << "done." << endl;
-    ::train(encdec, *trainer, prefix, valid_ppl);
+    ::train(encdec, trainer, prefix, valid_ppl);
   } else {  // mode == "test"
     cerr << "loading model ... ";
     ::EncoderDecoder<Tensor> encdec("encdec", prefix + '.');

--- a/primitiv/messages.proto
+++ b/primitiv/messages.proto
@@ -17,8 +17,7 @@ message Parameter {
   map<string, Tensor> stats = 2;
 }
 
-message TrainerConfigs {
-  string name = 1;
+message Trainer {
   map<string, uint32> uint_configs = 2;
   map<string, float> float_configs = 3;
 }

--- a/primitiv/trainer.h
+++ b/primitiv/trainer.h
@@ -23,30 +23,16 @@ public:
   Trainer() : epoch_(0), lr_scale_(1), l2_strength_(0), clip_threshold_(0) {}
 
   /**
-   * Retrieves a trainer name from a file.
-   * @param path Path of the file that stores trainer parameters.
-   * @return Corresponding trainer name.
-   */
-  static std::string detect_name(const std::string &path);
-
-  /**
-   * Loads a trainer from a file.
+   * Loads configurations from a file.
    * @param path Path of the trainer parameter file.
-   * @return A shared pointer of the Trainer object.
    */
-  static std::shared_ptr<Trainer> load(const std::string &path);
+  void load(const std::string &path);
 
   /**
-   * Saves the parameters to a file.
+   * Saves current configurations to a file.
    * @param path Path of the file that will store trainer parameters.
    */
   void save(const std::string &path) const;
-
-  /**
-   * Retrieves the name of the trainer.
-   * @return Name of the trainer.
-   */
-  virtual std::string name() const = 0;
 
   /**
    * Retrieves current epoch.
@@ -144,12 +130,6 @@ public:
   virtual void set_configs(
       const std::unordered_map<std::string, unsigned> &uint_configs,
       const std::unordered_map<std::string, float> &float_configs);
-
-  /**
-   * Sets configuration values using a file.
-   * @param path Path of the trainer parameter file.
-   */
-  void set_configs_by_file(const std::string &path);
 
 private:
   unsigned epoch_;

--- a/primitiv/trainer_impl.cc
+++ b/primitiv/trainer_impl.cc
@@ -9,6 +9,14 @@
 namespace primitiv {
 namespace trainers {
 
+#define SET_CONFIG(dest, cfg, key) { \
+  const auto it = cfg.find(key); \
+  if (it == cfg.end()) { \
+    THROW_ERROR("Key not found in the trainer config: " << key); \
+  } \
+  dest = it->second; \
+}
+
 void SGD::configure_parameter(Parameter &param) {}
 
 void SGD::update_parameter(float scale, Parameter &param) {
@@ -26,7 +34,7 @@ void SGD::set_configs(
     const std::unordered_map<std::string, unsigned> &uint_configs,
     const std::unordered_map<std::string, float> &float_configs) {
   Trainer::set_configs(uint_configs, float_configs);
-  eta_ = float_configs.at("SGD.eta");
+  SET_CONFIG(eta_, float_configs, "SGD.eta");
 }
 
 void MomentumSGD::configure_parameter(Parameter &param) {
@@ -56,8 +64,8 @@ void MomentumSGD::set_configs(
     const std::unordered_map<std::string, unsigned> &uint_configs,
     const std::unordered_map<std::string, float> &float_configs) {
   Trainer::set_configs(uint_configs, float_configs);
-  eta_ = float_configs.at("MomentumSGD.eta");
-  momentum_ = float_configs.at("MomentumSGD.momentum");
+  SET_CONFIG(eta_, float_configs, "MomentumSGD.eta");
+  SET_CONFIG(momentum_, float_configs, "MomentumSGD.momentum");
 }
 
 void AdaGrad::configure_parameter(Parameter &param) {
@@ -87,8 +95,8 @@ void AdaGrad::set_configs(
     const std::unordered_map<std::string, unsigned> &uint_configs,
     const std::unordered_map<std::string, float> &float_configs) {
   Trainer::set_configs(uint_configs, float_configs);
-  eta_ = float_configs.at("AdaGrad.eta");
-  eps_ = float_configs.at("AdaGrad.eps");
+  SET_CONFIG(eta_, float_configs, "AdaGrad.eta");
+  SET_CONFIG(eps_, float_configs, "AdaGrad.eps");
 }
 
 void RMSProp::configure_parameter(Parameter &param) {
@@ -119,9 +127,9 @@ void RMSProp::set_configs(
     const std::unordered_map<std::string, unsigned> &uint_configs,
     const std::unordered_map<std::string, float> &float_configs) {
   Trainer::set_configs(uint_configs, float_configs);
-  eta_ = float_configs.at("RMSProp.eta");
-  alpha_ = float_configs.at("RMSProp.alpha");
-  eps_ = float_configs.at("RMSProp.eps");
+  SET_CONFIG(eta_, float_configs, "RMSProp.eta");
+  SET_CONFIG(alpha_, float_configs, "RMSProp.alpha");
+  SET_CONFIG(eps_, float_configs, "RMSProp.eps");
 }
 
 void AdaDelta::configure_parameter(Parameter &param) {
@@ -157,8 +165,8 @@ void AdaDelta::set_configs(
     const std::unordered_map<std::string, unsigned> &uint_configs,
     const std::unordered_map<std::string, float> &float_configs) {
   Trainer::set_configs(uint_configs, float_configs);
-  rho_ = float_configs.at("AdaDelta.rho");
-  eps_ = float_configs.at("AdaDelta.eps");
+  SET_CONFIG(rho_, float_configs, "AdaDelta.rho");
+  SET_CONFIG(eps_, float_configs, "AdaDelta.eps");
 }
 
 void Adam::configure_parameter(Parameter &param) {
@@ -196,11 +204,13 @@ void Adam::set_configs(
     const std::unordered_map<std::string, unsigned> &uint_configs,
     const std::unordered_map<std::string, float> &float_configs) {
   Trainer::set_configs(uint_configs, float_configs);
-  alpha_ = float_configs.at("Adam.alpha");
-  beta1_ = float_configs.at("Adam.beta1");
-  beta2_ = float_configs.at("Adam.beta2");
-  eps_ = float_configs.at("Adam.eps");
+  SET_CONFIG(alpha_, float_configs, "Adam.alpha");
+  SET_CONFIG(beta1_, float_configs, "Adam.beta1");
+  SET_CONFIG(beta2_, float_configs, "Adam.beta2");
+  SET_CONFIG(eps_, float_configs, "Adam.eps");
 }
+
+#undef SET_CONFIG
 
 }  // namespace trainers
 }  // namespace primitiv

--- a/primitiv/trainer_impl.h
+++ b/primitiv/trainer_impl.h
@@ -6,7 +6,7 @@
 namespace primitiv {
 namespace trainers {
 
-#define DECL_DEFAULTS(name_) \
+#define DECL_DEFAULTS \
 public: \
   void get_configs( \
       std::unordered_map<std::string, unsigned> &uint_configs, \
@@ -22,7 +22,7 @@ private: \
  * Simple stochastic gradient descent.
  */
 class SGD : public primitiv::Trainer {
-  DECL_DEFAULTS(SGD);
+  DECL_DEFAULTS;
 
 public:
   /**
@@ -45,7 +45,7 @@ private:
  * Stochastic gradient descent with momentum.
  */
 class MomentumSGD : public primitiv::Trainer {
-  DECL_DEFAULTS(MomentumSGD);
+  DECL_DEFAULTS;
 
 public:
   /**
@@ -77,7 +77,7 @@ private:
  * AdaGrad optimizer.
  */
 class AdaGrad : public primitiv::Trainer {
-  DECL_DEFAULTS(AdaGrad);
+  DECL_DEFAULTS;
 
 public:
   /**
@@ -109,7 +109,7 @@ private:
  * RMSProp Optimizer.
  */
 class RMSProp : public primitiv::Trainer {
-  DECL_DEFAULTS(RMSProp);
+  DECL_DEFAULTS;
 
 public:
   /**
@@ -150,7 +150,7 @@ private:
  * https://arxiv.org/abs/1212.5701
  */
 class AdaDelta : public primitiv::Trainer {
-  DECL_DEFAULTS(AdaDelta);
+  DECL_DEFAULTS;
 
 public:
   /**
@@ -183,7 +183,7 @@ private:
  * https://arxiv.org/abs/1412.6980
  */
 class Adam : public primitiv::Trainer {
-  DECL_DEFAULTS(Adam);
+  DECL_DEFAULTS;
 
 public:
   /**

--- a/primitiv/trainer_impl.h
+++ b/primitiv/trainer_impl.h
@@ -8,7 +8,6 @@ namespace trainers {
 
 #define DECL_DEFAULTS(name_) \
 public: \
-  std::string name() const override { return #name_; } \
   void get_configs( \
       std::unordered_map<std::string, unsigned> &uint_configs, \
       std::unordered_map<std::string, float> &float_configs) const override; \


### PR DESCRIPTION
Related to #36.
This PR removes:

* `Trainer::load` static function
* `Trainer::name` function
* `Trainer::detect_name` function

And replaces:

* `Trainer::set_configs_by_file` -> `Trainer::load`.