### PR TITLE
Add Noncopyable and Nonmovable mix-in classes.

### DIFF
--- a/primitiv/cuda_device.h
+++ b/primitiv/cuda_device.h
@@ -16,10 +16,6 @@ struct CUDAInternalState;
  */
 class CUDA : public Device {
   CUDA() = delete;
-  CUDA(const CUDA &) = delete;
-  CUDA(CUDA &&) = delete;
-  CUDA &operator=(const CUDA &) = delete;
-  CUDA &operator=(CUDA &&) = delete;
 
 public:
   /** Retrieves the number of active hardwares.

--- a/primitiv/cuda_memory_pool.h
+++ b/primitiv/cuda_memory_pool.h
@@ -6,6 +6,8 @@
 #include <unordered_map>
 #include <vector>
 
+#include <primitiv/mixins.h>
+
 namespace primitiv {
 
 class CUDAMemoryDeleter;
@@ -13,14 +15,10 @@ class CUDAMemoryDeleter;
 /**
  * Memory manager on the CUDA devices.
  */
-class CUDAMemoryPool {
+class CUDAMemoryPool : mixins::Nonmovable<CUDAMemoryPool> {
   friend CUDAMemoryDeleter;
 
   CUDAMemoryPool() = delete;
-  CUDAMemoryPool(const CUDAMemoryPool &) = delete;
-  CUDAMemoryPool(CUDAMemoryPool &&) = delete;
-  CUDAMemoryPool &operator=(const CUDAMemoryPool &) = delete;
-  CUDAMemoryPool &operator=(CUDAMemoryPool &&) = delete;
 
 public:
   /**

--- a/primitiv/device.h
+++ b/primitiv/device.h
@@ -11,13 +11,10 @@ namespace primitiv {
 /**
  * Interface of the Tensor provider.
  */
-class Device : public mixins::DefaultSettable<Device> {
+class Device
+    : public mixins::DefaultSettable<Device>
+    , mixins::Nonmovable<Device> {
   friend Tensor;
-
-  Device(const Device &) = delete;
-  Device(Device &&) = delete;
-  Device &operator=(const Device &) = delete;
-  Device &operator=(Device &&) = delete;
 
 public:
   /**

--- a/primitiv/function.h
+++ b/primitiv/function.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <vector>
+#include <primitiv/mixins.h>
 #include <primitiv/shape.h>
 #include <primitiv/tensor.h>
 
@@ -13,12 +14,7 @@ class Device;
 /**
  * Interface of the function on the computation graph.
  */
-class Function {
-  Function(const Function &) = delete;
-  Function(Function &&) = delete;
-  Function &operator=(const Function &) = delete;
-  Function &operator=(Function &&) = delete;
-
+class Function : mixins::Nonmovable<Function> {
 public:
   Function() = default;
   virtual ~Function() = default;

--- a/primitiv/function_impl.h
+++ b/primitiv/function_impl.h
@@ -12,11 +12,6 @@ class Device;
 namespace functions {
 
 #define DEFAULT_CLASS_DECL(name_) \
-private: \
-  name_(const name_ &) = delete; \
-  name_(name_ &&) = delete; \
-  name_ &operator=(const name_ &) = delete; \
-  name_ &operator=(name_ &&) = delete; \
 public: \
   Shape forward_shape(const std::vector<const Shape *> &args) const override; \
   Tensor forward(const std::vector<const Tensor *> &args) override; \

--- a/primitiv/graph.h
+++ b/primitiv/graph.h
@@ -137,12 +137,9 @@ private:
 /**
  * Computation graph.
  */
-class Graph : public mixins::DefaultSettable<Graph> {
-  Graph(const Graph &) = delete;
-  Graph(Graph &&) = delete;
-  Graph &operator=(const Graph &) = delete;
-  Graph &operator=(Graph &&) = delete;
-
+class Graph
+    : public mixins::DefaultSettable<Graph>
+    , mixins::Nonmovable<Graph> {
 public:
   Graph() = default;
   ~Graph() = default;

--- a/primitiv/initializer.h
+++ b/primitiv/initializer.h
@@ -1,6 +1,8 @@
 #ifndef PRIMITIV_INITIALIZER_H_
 #define PRIMITIV_INITIALIZER_H_
 
+#include <primitiv/mixins.h>
+
 namespace primitiv {
 
 class Tensor;
@@ -8,12 +10,7 @@ class Tensor;
 /**
  * Abstract class to provide parameter initialization algorithms.
  */
-class Initializer {
-  Initializer(const Initializer &) = delete;
-  Initializer(Initializer &&) = delete;
-  Initializer &operator=(const Initializer &) = delete;
-  Initializer &operator=(Initializer &&) = delete;
-
+class Initializer : mixins::Nonmovable<Initializer> {
 public:
   Initializer() = default;
   virtual ~Initializer() = default;

--- a/primitiv/initializer_impl.h
+++ b/primitiv/initializer_impl.h
@@ -11,10 +11,6 @@ namespace initializers {
  */
 class Constant : public Initializer {
   Constant() = delete;
-  Constant(const Constant &) = delete;
-  Constant(Constant &&) = delete;
-  Constant &operator=(const Constant &) = delete;
-  Constant &operator=(Constant &&) = delete;
 
 public:
   /**
@@ -33,11 +29,6 @@ private:
  * Initializer using a parameterized uniform distribution (lower, upper].
  */
 class Uniform : public Initializer {
-  Uniform(const Uniform &) = delete;
-  Uniform(Uniform &&) = delete;
-  Uniform &operator=(const Uniform &) = delete;
-  Uniform &operator=(Uniform &&) = delete;
-
 public:
   Uniform(float lower, float upper) : lower_(lower), upper_(upper) {}
 
@@ -52,11 +43,6 @@ private:
  * Initializer using a parameterized normal distribution N(mean, sd).
  */
 class Normal : public Initializer {
-  Normal(const Normal &) = delete;
-  Normal(Normal &&) = delete;
-  Normal &operator=(const Normal &) = delete;
-  Normal &operator=(Normal &&) = delete;
-
 public:
   Normal(float mean, float sd) : mean_(mean), sd_(sd) {}
 
@@ -71,11 +57,6 @@ private:
  * Identity matrix initializer.
  */
 class Identity : public Initializer {
-  Identity(const Identity &) = delete;
-  Identity(Identity &&) = delete;
-  Identity &operator=(const Identity &) = delete;
-  Identity &operator=(Identity &&) = delete;
-
 public:
   Identity() {}
 
@@ -86,11 +67,6 @@ public:
  * The Xavier matrix initialization with the uniform distribution.
  */
 class XavierUniform : public Initializer {
-  XavierUniform(const XavierUniform &) = delete;
-  XavierUniform(XavierUniform &&) = delete;
-  XavierUniform &operator=(const XavierUniform &) = delete;
-  XavierUniform &operator=(XavierUniform &&) = delete;
-
 public:
   XavierUniform(float scale = 1.0f) : scale_(scale) {}
 
@@ -104,11 +80,6 @@ private:
  * The Xavier matrix initialization with the normal distribution.
  */
 class XavierNormal : public Initializer {
-  XavierNormal(const XavierNormal &) = delete;
-  XavierNormal(XavierNormal &&) = delete;
-  XavierNormal &operator=(const XavierNormal &) = delete;
-  XavierNormal &operator=(XavierNormal &&) = delete;
-
 public:
   XavierNormal(float scale = 1.0f) : scale_(scale) {}
 

--- a/primitiv/mixins.h
+++ b/primitiv/mixins.h
@@ -21,7 +21,7 @@ class DefaultSettable {
    */
   static T *default_obj_;
 
-public:
+protected:
   DefaultSettable() = default;
 
   ~DefaultSettable() {
@@ -31,6 +31,7 @@ public:
     }
   }
 
+public:
   /**
    * Retrieves the current default object.
    * @return Reference of the current default object.

--- a/primitiv/mixins.h
+++ b/primitiv/mixins.h
@@ -7,6 +7,34 @@ namespace primitiv {
 namespace mixins {
 
 /**
+ * Mix-in class to prohibit copying.
+ */
+template<typename T>
+class Noncopyable {
+private:
+  Noncopyable(const Noncopyable &) = delete;
+  Noncopyable &operator=(const Noncopyable &) = delete;
+protected:
+  Noncopyable() = default;
+  ~Noncopyable() = default;
+};
+
+/**
+ * Mix-in class to prohibit moving and copying.
+ */
+template<typename T>
+class Nonmovable {
+private:
+  Nonmovable(const Nonmovable &) = delete;
+  Nonmovable(Nonmovable &&) = delete;
+  Nonmovable &operator=(const Nonmovable &) = delete;
+  Nonmovable &operator=(Nonmovable &&) = delete;
+protected:
+  Nonmovable() = default;
+  ~Nonmovable() = default;
+};
+
+/**
  * Mix-in class to provide default value setter/getter.
  */
 template<typename T>

--- a/primitiv/naive_device.h
+++ b/primitiv/naive_device.h
@@ -11,11 +11,6 @@ namespace devices {
  * Device class for the naive function implementations on CPU.
  */
 class Naive : public Device {
-  Naive(const Naive &) = delete;
-  Naive(Naive &&) = delete;
-  Naive &operator=(const Naive &) = delete;
-  Naive &operator=(Naive &&) = delete;
-
 public:
   /**
    * Creates a Naive object.

--- a/primitiv/parameter.h
+++ b/primitiv/parameter.h
@@ -6,6 +6,7 @@
 #include <vector>
 #include <primitiv/device.h>
 #include <primitiv/error.h>
+#include <primitiv/mixins.h>
 #include <primitiv/shape.h>
 #include <primitiv/tensor.h>
 
@@ -16,10 +17,7 @@ class Initializer;
 /**
  * Class to manage a trainable tensor parameter.
  */
-class Parameter {
-  Parameter(const Parameter &) = delete;
-  Parameter &operator=(const Parameter &) = delete;
-
+class Parameter : mixins::Noncopyable<Parameter> {
 public:
   Parameter(Parameter &&src)
     : shape_(std::move(src.shape_))

--- a/primitiv/trainer.h
+++ b/primitiv/trainer.h
@@ -4,6 +4,7 @@
 #include <memory>
 #include <unordered_set>
 #include <primitiv/error.h>
+#include <primitiv/mixins.h>
 
 namespace primitiv {
 
@@ -12,15 +13,11 @@ class Parameter;
 /**
  * Abstract class for parameter optimizers.
  */
-class Trainer {
+class Trainer : mixins::Nonmovable<Trainer> {
 public:
-  Trainer(const Trainer &) = default;
-  Trainer(Trainer &&) = default;
-  Trainer &operator=(const Trainer &) = default;
-  Trainer &operator=(Trainer &&) = default;
-  virtual ~Trainer() = default;
-
   Trainer() : epoch_(0), lr_scale_(1), l2_strength_(0), clip_threshold_(0) {}
+
+  virtual ~Trainer() = default;
 
   /**
    * Loads configurations from a file.

--- a/primitiv/type_traits.h
+++ b/primitiv/type_traits.h
@@ -42,11 +42,6 @@ using ReducePtr = typename std::enable_if<
   >::type
 >::type;
 
-// Returns true_type if T is Device or Graph.
-template<typename T> struct is_scoped : std::false_type {};
-template<> struct is_scoped<Device> : std::true_type {};
-template<> struct is_scoped<Graph> : std::true_type {};
-
 }  // namespace type_traits
 
 }  // namespace primitiv


### PR DESCRIPTION
This PR adds following mix-in classes:
* `primitiv::mixins::Noncopyable<T>`: Prohibits copy c-tor/assignment.
* `primitiv::mixins::Nonmovable<T>`: Prohibits copy/move c-tors/assignments.

And small fix: remove unused class `primitiv::type_traits::is_scoped<T>`.