### PR TITLE
Add Travis CI tracker about master/develop.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 [![c++](https://img.shields.io/badge/c%2B%2B-11-blue.svg)]()
 [![python](https://img.shields.io/badge/python-3.5-blue.svg)]()
 [![license](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-[![Build Status (master)](https://img.shields.io/travis/odashi/primitiv/master.svg?label=build+%28master%29)](https://travic-ci.org/odashi/primitiv)
-[![Build Status (develop)](https://img.shields.io/travis/odashi/primitiv/develop.svg?label=build+%28develop%29)](https://travic-ci.org/odashi/primitiv)
+[![Build Status (master)](https://img.shields.io/travis/odashi/primitiv/master.svg?label=build+%28master%29)](https://travis-ci.org/odashi/primitiv)
+[![Build Status (develop)](https://img.shields.io/travis/odashi/primitiv/develop.svg?label=build+%28develop%29)](https://travis-ci.org/odashi/primitiv)
 
 primitiv
 ========

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 [![c++](https://img.shields.io/badge/c%2B%2B-11-blue.svg)]()
 [![python](https://img.shields.io/badge/python-3.5-blue.svg)]()
 [![license](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
-[![Build Status](https://api.travis-ci.org/odashi/primitiv.svg?branch=develop)](https://travis-ci.org/odashi/primitiv)
+[![Build Status (master)](https://img.shields.io/travis/odashi/primitiv/master.svg?label=build+%28master%29)](https://travic-ci.org/odashi/primitiv)
+[![Build Status (develop)](https://img.shields.io/travis/odashi/primitiv/develop.svg?label=build+%28develop%29)](https://travic-ci.org/odashi/primitiv)
 
 primitiv
 ========


### PR DESCRIPTION
This PR allows us to show Travis CI results on both `master` and `develop` branches separately.