### PR TITLE
Specify build directory of Cython

### DIFF
--- a/python-primitiv/setup.py
+++ b/python-primitiv/setup.py
@@ -68,7 +68,7 @@ setup(
         "Programming Language :: Python :: 3",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
     ],
-    ext_modules = cythonize(ext_modules),
+    ext_modules = cythonize(ext_modules, build_dir="build"),
     packages = [
         "primitiv",
         "primitiv.devices",


### PR DESCRIPTION
This branch specifies the build directory to generate `*.cpp` files into `python-primitiv/build/primitiv/`