### PR TITLE
Fix/python param order

### DIFF
--- a/python-primitiv/primitiv/_parameter.pyx
+++ b/python-primitiv/primitiv/_parameter.pyx
@@ -11,6 +11,7 @@ from primitiv.config cimport pystr_to_cppstr
 from weakref import WeakValueDictionary
 
 import numpy as np
+cimport numpy as np
 import weakref
 
 # NOTE(vbkaisetsu):
@@ -45,11 +46,12 @@ cdef class _Parameter:
     def __cinit__(self):
         self.stats = _ParameterStatistics(self)
 
-    def __init__(self, shape = None, initializer = None, _Device device = None):
+    def __init__(self, *args, **kwargs):
         if self.wrapped is not NULL:
             raise TypeError("__init__() has already been called.")
         self.wrapped = new CppParameter()
-        self.init(shape, initializer, device)
+        if len(args) != 0 or len(kwargs) != 0:
+            self.init(*args, **kwargs)
         _Parameter.register_wrapper(self.wrapped, self)
 
     def __dealloc__(self):
@@ -57,27 +59,12 @@ cdef class _Parameter:
             del self.wrapped
             self.wrapped = NULL
 
-    def init(self, shape = None, initializer = None, _Device device = None):
+    # NOTE(vbkaisetsu):
+    # Python's Parameter.init only takes shape+Initializer arguments.
+    def init(self, shape, _Initializer initializer, _Device device = None):
         if device is None:
             device = _Device.get_default()
-        if isinstance(initializer, np.ndarray):
-            if shape is None:
-                shape = _Shape(initializer.shape, 1)
-            self.wrapped.init(normShape(shape).wrapped, ndarrays_to_vector([initializer]), device.wrapped[0])
-        elif isinstance(initializer, _Initializer):
-            if shape is None:
-                raise TypeError("shape is required when initializer is an Initializer")
-            self.wrapped.init(normShape(shape).wrapped, (<_Initializer> initializer).wrapped[0], device.wrapped[0])
-        elif isinstance(initializer, list):
-            if shape is None:
-                raise TypeError("shape is required when initializer is a list")
-            self.wrapped.init(normShape(shape).wrapped, <vector[float]> initializer, device.wrapped[0])
-        elif initializer is None:
-            if shape is not None:
-                raise TypeError("shape is given but initializer is not given")
-        else:
-            raise TypeError("Argument 'initializer' has incorrect type (list, Initializer, or numpy.ndarray)")
-        return
+        self.wrapped.init(normShape(shape).wrapped, initializer.wrapped[0], device.wrapped[0])
 
     def load(self, str path, bool with_stats = True, _Device device = None):
         if device is None:

--- a/python-primitiv/tests/check_arguments.py
+++ b/python-primitiv/tests/check_arguments.py
@@ -53,26 +53,16 @@ class ArgumentTest(unittest.TestCase):
         self.assertEqual(x.to_list(), self.list_data)
         self.assertEqual(x.shape(), Shape([4, 3], 2))
 
-        # list[ndarray] w/ shape
-        x = F.input(self.ndarray_data, Shape([2, 3], 4))
-        self.assertEqual(x.to_list(), self.list_data)
-        self.assertEqual(x.shape(), Shape([2, 3], 4))
-
         # ndarray w/o shape
         x = F.input(self.ndarray_data[0])
         self.assertEqual(x.to_list(), self.list_data[:12])
         self.assertEqual(x.shape(), Shape([4, 3], 1))
 
-        # ndarray w/ shape
-        x = F.input(self.ndarray_data[0], Shape([2, 3], 2))
-        self.assertEqual(x.to_list(), self.list_data[:12])
-        self.assertEqual(x.shape(), Shape([2, 3], 2))
-
         # list[float] w/o shape
         self.assertRaises(TypeError, lambda: F.input(self.list_data))
 
         # list[float] w/ shape
-        x = F.input(self.list_data, shape=Shape([4, 3], 2))
+        x = F.raw_input(Shape([4, 3], 2), self.list_data)
         self.assertEqual(x.to_list(), self.list_data)
         self.assertEqual(x.shape(), Shape([4, 3], 2))
 
@@ -85,21 +75,3 @@ class ArgumentTest(unittest.TestCase):
         p = Parameter(Shape([4, 3]), I.Constant(1))
         self.assertEqual(p.shape(), Shape([4, 3]))
         self.assertEqual(p.value.to_list(), [1] * 12)
-
-        # shape w/ list[float]
-        p = Parameter(Shape([4, 3]), self.list_data[:12])
-        self.assertEqual(p.shape(), Shape([4, 3]))
-        self.assertEqual(p.value.to_list(), self.list_data[:12])
-
-        # ndarray w/o shape
-        p = Parameter(initializer=self.ndarray_data[0])
-        self.assertEqual(p.shape(), Shape([4, 3]))
-        self.assertEqual(p.value.to_list(), self.list_data[:12])
-
-        # ndarray w/ shape
-        p = Parameter(Shape([2, 6]), initializer=self.ndarray_data[0])
-        self.assertEqual(p.shape(), Shape([2, 6]))
-        self.assertEqual(p.value.to_list(), self.list_data[:12])
-
-        # list[float] w/o shape
-        self.assertRaises(TypeError, lambda: Parameter(initializer=self.list_data[:12]))

--- a/python-primitiv/tests/instance_match.py
+++ b/python-primitiv/tests/instance_match.py
@@ -35,25 +35,25 @@ class ArgumentTest(unittest.TestCase):
         dev = Device.get_default()
         self.assertIs(dev, self.device)
 
-        tensor = tF.input([0], Shape([]))
-        dev = tensor.device()
-        self.assertIs(dev, self.device)
+        tensor = tF.raw_input([], [0])
+        #dev = tensor.device()
+        #self.assertIs(dev, self.device)
 
-        node = F.input([0], Shape([]))
+        node = F.raw_input([], [0])
         dev = node.device()
         self.assertIs(dev, self.device)
 
         my_device = Naive()
         self.assertIsNot(my_device, self.device)
 
-        node = F.input([0], Shape([]), device=my_device)
+        node = F.raw_input([], [0], device=my_device)
         dev = node.device()
         self.assertIs(dev, my_device)
 
         dev = self.graph.get_device(node)
         self.assertIs(dev, my_device)
 
-        param = Parameter(Shape([]), [0])
+        param = Parameter([], I.Constant(1))
         dev = param.device()
         self.assertIs(dev, self.device)
 
@@ -61,12 +61,12 @@ class ArgumentTest(unittest.TestCase):
         g = Graph.get_default()
         self.assertIs(g, self.graph)
 
-        node = F.input([0], Shape([]))
+        node = F.raw_input([], [0])
         g = node.graph()
         self.assertIs(g, self.graph)
 
     def test_tensor_instance(self):
-        param = Parameter(Shape([]), [0])
+        param = Parameter([], I.Constant(1))
         t_origin = param.gradient
         t = param.gradient
         self.assertIs(t, t_origin)

--- a/python-primitiv/tests/parameter.py
+++ b/python-primitiv/tests/parameter.py
@@ -24,7 +24,8 @@ class ParameterTest(unittest.TestCase):
     def setUp(self):
         self.dev = D.Naive()
         Device.set_default(self.dev)
-        self.p = Parameter(initializer=np.array([1, 2, 3, 4, 5, 6, 7, 8]))
+        self.p = Parameter([8], I.Constant(0))
+        self.p.value.reset_by_vector([1, 2, 3, 4, 5, 6, 7, 8])
 
     def tearDown(self):
          pass

--- a/python-primitiv/tests/python_trainer.py
+++ b/python-primitiv/tests/python_trainer.py
@@ -95,7 +95,7 @@ def train_func(trainer):
 
     for i in range(10):
         g.clear()
-        x = F.input(input_data, Shape([2], 4))
+        x = F.raw_input(Shape([2], 4), input_data)
         w1 = F.parameter(pw1)
         b1 = F.parameter(pb1)
         w2 = F.parameter(pw2)
@@ -103,7 +103,7 @@ def train_func(trainer):
         h = F.tanh(w1 @ x + b1)
         y = w2 @ h + b2
 
-        t = F.input(output_data, Shape([], 4))
+        t = F.raw_input(Shape([], 4), output_data)
         diff = t - y
         loss = F.batch.mean(diff * diff)
 
@@ -189,7 +189,7 @@ class PythonTrainerTest(unittest.TestCase):
         dev = D.Naive()
         Device.set_default(dev)
         trainer = ExceptionTrainer()
-        p = Parameter(Shape([]), [0])
+        p = Parameter()
         with self.assertRaises(TestException) as ctx:
             trainer.add_parameter(p)
         self.assertEqual(str(ctx.exception), "configure_parameter")
@@ -211,7 +211,7 @@ class PythonTrainerTest(unittest.TestCase):
         dev = D.Naive()
         Device.set_default(dev)
         trainer = IncompleteTrainer()
-        p = Parameter(Shape([]), [0])
+        p = Parameter()
         with self.assertRaises(NotImplementedError):
             trainer.add_parameter(p)
         with self.assertRaises(NotImplementedError):


### PR DESCRIPTION
Related to: #57
This branch supports multiple dispatch ("overload" in C++) using variable arguments and exceptions.

```
Parameter.init(Shape, list, Device: optional)
          or  (Shape, Initializer, Device: optional)
          or  (np.ndarray, Device: optional)

operators.input(Shape, list, Device: optional, Graph: optional)
           or  (list[np.ndarray], Device: optional, Graph: optional)
           or  (np.ndarray, Device: optional, Graph: optional)
```