### PR TITLE
Fix/python input n parameter args

### DIFF
--- a/python-primitiv/primitiv/_operator.pyx
+++ b/python-primitiv/primitiv/_operator.pyx
@@ -29,10 +29,10 @@ class _operators:
     # instead of a vector.
     @staticmethod
     def input(data, _Device device = None, _Graph g = None):
-        cdef vector[float] vec
         # NOTE(vbkaisetsu)
-        # Shape does not allow an empty matrix.
-        # This function does not check it.
+        # When data contains no element, its shape becomes (0,).
+        # primitiv.Shape does not allow (0,) and raises an error, so this
+        # function does not check item existence of a given data.
         if isinstance(data, np.ndarray):
             data = [data]
         if isinstance(data, list):
@@ -320,10 +320,10 @@ class _tensor_operators:
     # instead of a vector.
     @staticmethod
     def input(data, _Device device = None):
-        cdef vector[float] vec
         # NOTE(vbkaisetsu)
-        # Shape does not allow an empty matrix.
-        # This function does not check it.
+        # When data contains no element, its shape becomes (0,).
+        # primitiv.Shape does not allow (0,) and raises an error, so this
+        # function does not check item existence of a given data.
         if isinstance(data, np.ndarray):
             data = [data]
         if isinstance(data, list):

--- a/python-primitiv/primitiv/_operator.pyx
+++ b/python-primitiv/primitiv/_operator.pyx
@@ -40,12 +40,12 @@ class _operators:
             data = [data]
         if isinstance(data, list):
             if len(data) == 0:
-                raise TypeError("list is given but it contains no item")
+                raise TypeError("`data` contains no item.")
             if not isinstance(data[0], np.ndarray):
-                raise TypeError("list contains items but it is not np.ndarray")
+                raise TypeError("`data` contains other objects than numpy.ndarray.")
             shape = _Shape(data[0].shape, len(data))
         else:
-            raise TypeError("Argument 'data' has incorrect type (list of np.ndarray, or np.ndarray)")
+            raise TypeError("`data` has incorrect type.")
         return _operators.raw_input(shape, ndarrays_to_vector(data), device, g)
 
 
@@ -117,7 +117,7 @@ class _operators:
         elif isinstance(x, _Node) and isinstance(k, _Node):
             return wrapNode(op_pow((<_Node> x).wrapped, (<_Node> k).wrapped))
         else:
-            raise TypeError("Argument 'x' or 'k' has incorrect type (Node or float or int)")
+            raise TypeError("`x` or `k` has incorrect type.")
 
     @staticmethod
     def tanh(_Node x):
@@ -208,7 +208,7 @@ class _operators:
         elif isinstance(t, list):
             return wrapNode(op_softmax_cross_entropy(x.wrapped, <vector[unsigned]> t, dim))
         else:
-            raise TypeError("Argument 't' has incorrect type (list or Node)")
+            raise TypeError("`t` has incorrect type.")
 
     @staticmethod
     def constant(shape, float k, _Device device = None, _Graph g = None):
@@ -323,23 +323,23 @@ class _tensor_operators:
     # instead of a vector.
     @staticmethod
     def input(data, _Device device = None):
-        # NOTE(vbkaisetsu)
-        # In this function, we don't check whether an ndarray contains elements or not.
-        # When an ndarray contains no element, the ndarray's shape becomes (0,).
-        # primitiv.Shape does not allow (0,) and raises an error.
-        #
-        # In this function, we don't check whether each ndarray object has same shape or not.
+        # NOTE(vbkaisetsu, odashi):
+        # In this function, we don't check whether each ndarray is empty
+        # (i.e., it doesn't have any elements) or not.
+        # When the ndarray contains no element, its shape becomes (0,),
+        # and primitiv.Shape will reject the shape and raises an exception.
+        # In addition, we also don't check whether each ndarray has the same shape or not.
         # This condition will be checked in ndarrays_to_vector().
         if isinstance(data, np.ndarray):
             data = [data]
         if isinstance(data, list):
             if len(data) == 0:
-                raise TypeError("list is given but it contains no item")
+                raise TypeError("`data` contains no item.")
             if not isinstance(data[0], np.ndarray):
-                raise TypeError("list contains items but it is not np.ndarray")
+                raise TypeError("`data` contains other objects than numpy.ndarray.")
             shape = _Shape(data[0].shape, len(data))
         else:
-            raise TypeError("Argument 'data' has incorrect type (list of np.ndarray, or np.ndarray)")
+            raise TypeError("`data` has incorrect type.")
         return _tensor_operators.raw_input(shape, ndarrays_to_vector(data), device)
 
     @staticmethod
@@ -407,7 +407,7 @@ class _tensor_operators:
         elif isinstance(x, _Tensor) and isinstance(k, _Tensor):
             return _Tensor.get_wrapper_with_new(new CppTensor(op_pow((<_Tensor> x).wrapped[0], (<_Tensor> k).wrapped[0])))
         else:
-            raise TypeError("Argument 'x' or 'k' has incorrect type (Node or float or int)")
+            raise TypeError("`x` or `k` has incorrect type.")
 
     @staticmethod
     def tanh(_Tensor x):
@@ -498,7 +498,7 @@ class _tensor_operators:
         elif isinstance(t, list):
             return _Tensor.get_wrapper_with_new(new CppTensor(op_softmax_cross_entropy(x.wrapped[0], <vector[unsigned]> t, dim)))
         else:
-            raise TypeError("Argument 't' has incorrect type (list or Node)")
+            raise TypeError("`t` has incorrect type.")
 
     @staticmethod
     def constant(shape, float k, _Device device = None):

--- a/python-primitiv/primitiv/_operator.pyx
+++ b/python-primitiv/primitiv/_operator.pyx
@@ -29,14 +29,22 @@ class _operators:
     # instead of a vector.
     @staticmethod
     def input(data, _Device device = None, _Graph g = None):
+        cdef vector[float] vec
+        # NOTE(vbkaisetsu)
+        # Shape does not allow an empty matrix.
+        # This function does not check it.
         if isinstance(data, np.ndarray):
             data = [data]
-        if len(data) == 0:
-            raise TypeError("list is given but it contains no item")
-        if not isinstance(data[0], np.ndarray):
-            raise TypeError("list does not contain np.ndarray")
-        shape = _Shape(data[0].shape, len(data))
+        if isinstance(data, list):
+            if len(data) == 0:
+                raise TypeError("list is given but it contains no item")
+            if not isinstance(data[0], np.ndarray):
+                raise TypeError("list contains items but it is not np.ndarray")
+            shape = _Shape(data[0].shape, len(data))
+        else:
+            raise TypeError("Argument 'data' has incorrect type (list of np.ndarray, or np.ndarray)")
         return _operators.raw_input(shape, ndarrays_to_vector(data), device, g)
+
 
     @staticmethod
     def parameter(_Parameter param, _Graph g = None):
@@ -312,13 +320,20 @@ class _tensor_operators:
     # instead of a vector.
     @staticmethod
     def input(data, _Device device = None):
+        cdef vector[float] vec
+        # NOTE(vbkaisetsu)
+        # Shape does not allow an empty matrix.
+        # This function does not check it.
         if isinstance(data, np.ndarray):
             data = [data]
-        if len(data) == 0:
-            raise TypeError("list is given but it contains no item")
-        if not isinstance(data[0], np.ndarray):
-            raise TypeError("list does not contain np.ndarray")
-        shape = _Shape(data[0].shape, len(data))
+        if isinstance(data, list):
+            if len(data) == 0:
+                raise TypeError("list is given but it contains no item")
+            if not isinstance(data[0], np.ndarray):
+                raise TypeError("list contains items but it is not np.ndarray")
+            shape = _Shape(data[0].shape, len(data))
+        else:
+            raise TypeError("Argument 'data' has incorrect type (list of np.ndarray, or np.ndarray)")
         return _tensor_operators.raw_input(shape, ndarrays_to_vector(data), device)
 
     @staticmethod

--- a/python-primitiv/primitiv/_operator.pyx
+++ b/python-primitiv/primitiv/_operator.pyx
@@ -29,12 +29,12 @@ class _operators:
     # instead of a vector.
     @staticmethod
     def input(data, _Device device = None, _Graph g = None):
-        # NOTE(vbkaisetsu)
-        # In this function, we don't check whether an ndarray contains elements or not.
-        # When an ndarray contains no element, the ndarray's shape becomes (0,).
-        # primitiv.Shape does not allow (0,) and raises an error.
-        #
-        # In this function, we don't check whether each ndarray object has same shape or not.
+        # NOTE(vbkaisetsu, odashi):
+        # In this function, we don't check whether each ndarray is empty
+        # (i.e., it doesn't have any elements) or not.
+        # When the ndarray contains no element, its shape becomes (0,),
+        # and primitiv.Shape will reject the shape and raises an exception.
+        # In addition, we also don't check whether each ndarray has the same shape or not.
         # This condition will be checked in ndarrays_to_vector().
         if isinstance(data, np.ndarray):
             data = [data]

--- a/python-primitiv/primitiv/_operator.pyx
+++ b/python-primitiv/primitiv/_operator.pyx
@@ -15,6 +15,7 @@ import numpy as np
 
 class _operators:
 
+    @staticmethod
     def raw_input(shape, vector[float] data, _Device device = None, _Graph g = None):
         if device is None:
             device = _Device.get_default()
@@ -26,6 +27,7 @@ class _operators:
     # NOTE(vbkaisetsu)
     # This function takes an np.ndarray or a list of np.ndarray
     # instead of a vector.
+    @staticmethod
     def input(data, _Device device = None, _Graph g = None):
         if isinstance(data, np.ndarray):
             data = [data]
@@ -299,6 +301,7 @@ class _operators:
 
 class _tensor_operators:
 
+    @staticmethod
     def raw_input(shape, vector[float] data, _Device device = None):
         if device is None:
             device = _Device.get_default()
@@ -307,6 +310,7 @@ class _tensor_operators:
     # NOTE(vbkaisetsu)
     # This function takes an np.ndarray or a list of np.ndarray
     # instead of a vector.
+    @staticmethod
     def input(data, _Device device = None):
         if isinstance(data, np.ndarray):
             data = [data]

--- a/python-primitiv/primitiv/_operator.pyx
+++ b/python-primitiv/primitiv/_operator.pyx
@@ -30,9 +30,12 @@ class _operators:
     @staticmethod
     def input(data, _Device device = None, _Graph g = None):
         # NOTE(vbkaisetsu)
-        # When data contains no element, its shape becomes (0,).
-        # primitiv.Shape does not allow (0,) and raises an error, so this
-        # function does not check item existence of a given data.
+        # In this function, we don't check whether an ndarray contains elements or not.
+        # When an ndarray contains no element, the ndarray's shape becomes (0,).
+        # primitiv.Shape does not allow (0,) and raises an error.
+        #
+        # In this function, we don't check whether each ndarray object has same shape or not.
+        # This condition will be checked in ndarrays_to_vector().
         if isinstance(data, np.ndarray):
             data = [data]
         if isinstance(data, list):
@@ -321,9 +324,12 @@ class _tensor_operators:
     @staticmethod
     def input(data, _Device device = None):
         # NOTE(vbkaisetsu)
-        # When data contains no element, its shape becomes (0,).
-        # primitiv.Shape does not allow (0,) and raises an error, so this
-        # function does not check item existence of a given data.
+        # In this function, we don't check whether an ndarray contains elements or not.
+        # When an ndarray contains no element, the ndarray's shape becomes (0,).
+        # primitiv.Shape does not allow (0,) and raises an error.
+        #
+        # In this function, we don't check whether each ndarray object has same shape or not.
+        # This condition will be checked in ndarrays_to_vector().
         if isinstance(data, np.ndarray):
             data = [data]
         if isinstance(data, list):

--- a/python-primitiv/primitiv/_parameter.pyx
+++ b/python-primitiv/primitiv/_parameter.pyx
@@ -11,6 +11,7 @@ from primitiv.config cimport pystr_to_cppstr
 from weakref import WeakValueDictionary
 
 import numpy as np
+cimport numpy as np
 import weakref
 
 # NOTE(vbkaisetsu):
@@ -45,11 +46,12 @@ cdef class _Parameter:
     def __cinit__(self):
         self.stats = _ParameterStatistics(self)
 
-    def __init__(self, shape = None, initializer = None, _Device device = None):
+    def __init__(self, *args, **kwargs):
         if self.wrapped is not NULL:
             raise TypeError("__init__() has already been called.")
         self.wrapped = new CppParameter()
-        self.init(shape, initializer, device)
+        if len(args) != 0 or len(kwargs) != 0:
+            self.init(*args, **kwargs)
         _Parameter.register_wrapper(self.wrapped, self)
 
     def __dealloc__(self):
@@ -57,27 +59,12 @@ cdef class _Parameter:
             del self.wrapped
             self.wrapped = NULL
 
-    def init(self, shape = None, initializer = None, _Device device = None):
+    # NOTE(vbkaisetsu):
+    # Python's Parameter.init only takes shape+Initializer arguments.
+    def init(self, shape, _Initializer initializer, _Device device = None):
         if device is None:
             device = _Device.get_default()
-        if isinstance(initializer, np.ndarray):
-            if shape is None:
-                shape = _Shape(initializer.shape, 1)
-            self.wrapped.init(normShape(shape).wrapped, ndarrays_to_vector([initializer]), device.wrapped[0])
-        elif isinstance(initializer, _Initializer):
-            if shape is None:
-                raise TypeError("shape is required when initializer is an Initializer")
-            self.wrapped.init(normShape(shape).wrapped, (<_Initializer> initializer).wrapped[0], device.wrapped[0])
-        elif isinstance(initializer, list):
-            if shape is None:
-                raise TypeError("shape is required when initializer is a list")
-            self.wrapped.init(normShape(shape).wrapped, <vector[float]> initializer, device.wrapped[0])
-        elif initializer is None:
-            if shape is not None:
-                raise TypeError("shape is given but initializer is not given")
-        else:
-            raise TypeError("Argument 'initializer' has incorrect type (list, Initializer, or numpy.ndarray)")
-        return
+        self.wrapped.init(normShape(shape).wrapped, initializer.wrapped[0], device.wrapped[0])
 
     def load(self, str path, bool with_stats = True, _Device device = None):
         if device is None:

--- a/python-primitiv/tests/check_arguments.py
+++ b/python-primitiv/tests/check_arguments.py
@@ -53,26 +53,16 @@ class ArgumentTest(unittest.TestCase):
         self.assertEqual(x.to_list(), self.list_data)
         self.assertEqual(x.shape(), Shape([4, 3], 2))
 
-        # list[ndarray] w/ shape
-        x = F.input(self.ndarray_data, Shape([2, 3], 4))
-        self.assertEqual(x.to_list(), self.list_data)
-        self.assertEqual(x.shape(), Shape([2, 3], 4))
-
         # ndarray w/o shape
         x = F.input(self.ndarray_data[0])
         self.assertEqual(x.to_list(), self.list_data[:12])
         self.assertEqual(x.shape(), Shape([4, 3], 1))
 
-        # ndarray w/ shape
-        x = F.input(self.ndarray_data[0], Shape([2, 3], 2))
-        self.assertEqual(x.to_list(), self.list_data[:12])
-        self.assertEqual(x.shape(), Shape([2, 3], 2))
-
         # list[float] w/o shape
         self.assertRaises(TypeError, lambda: F.input(self.list_data))
 
         # list[float] w/ shape
-        x = F.input(self.list_data, shape=Shape([4, 3], 2))
+        x = F.raw_input(Shape([4, 3], 2), self.list_data)
         self.assertEqual(x.to_list(), self.list_data)
         self.assertEqual(x.shape(), Shape([4, 3], 2))
 
@@ -85,21 +75,3 @@ class ArgumentTest(unittest.TestCase):
         p = Parameter(Shape([4, 3]), I.Constant(1))
         self.assertEqual(p.shape(), Shape([4, 3]))
         self.assertEqual(p.value.to_list(), [1] * 12)
-
-        # shape w/ list[float]
-        p = Parameter(Shape([4, 3]), self.list_data[:12])
-        self.assertEqual(p.shape(), Shape([4, 3]))
-        self.assertEqual(p.value.to_list(), self.list_data[:12])
-
-        # ndarray w/o shape
-        p = Parameter(initializer=self.ndarray_data[0])
-        self.assertEqual(p.shape(), Shape([4, 3]))
-        self.assertEqual(p.value.to_list(), self.list_data[:12])
-
-        # ndarray w/ shape
-        p = Parameter(Shape([2, 6]), initializer=self.ndarray_data[0])
-        self.assertEqual(p.shape(), Shape([2, 6]))
-        self.assertEqual(p.value.to_list(), self.list_data[:12])
-
-        # list[float] w/o shape
-        self.assertRaises(TypeError, lambda: Parameter(initializer=self.list_data[:12]))

--- a/python-primitiv/tests/instance_match.py
+++ b/python-primitiv/tests/instance_match.py
@@ -36,8 +36,8 @@ class ArgumentTest(unittest.TestCase):
         self.assertIs(dev, self.device)
 
         tensor = tF.raw_input([], [0])
-        #dev = tensor.device()
-        #self.assertIs(dev, self.device)
+        dev = tensor.device()
+        self.assertIs(dev, self.device)
 
         node = F.raw_input([], [0])
         dev = node.device()

--- a/python-primitiv/tests/instance_match.py
+++ b/python-primitiv/tests/instance_match.py
@@ -35,25 +35,25 @@ class ArgumentTest(unittest.TestCase):
         dev = Device.get_default()
         self.assertIs(dev, self.device)
 
-        tensor = tF.input([0], Shape([]))
-        dev = tensor.device()
-        self.assertIs(dev, self.device)
+        tensor = tF.raw_input([], [0])
+        #dev = tensor.device()
+        #self.assertIs(dev, self.device)
 
-        node = F.input([0], Shape([]))
+        node = F.raw_input([], [0])
         dev = node.device()
         self.assertIs(dev, self.device)
 
         my_device = Naive()
         self.assertIsNot(my_device, self.device)
 
-        node = F.input([0], Shape([]), device=my_device)
+        node = F.raw_input([], [0], device=my_device)
         dev = node.device()
         self.assertIs(dev, my_device)
 
         dev = self.graph.get_device(node)
         self.assertIs(dev, my_device)
 
-        param = Parameter(Shape([]), [0])
+        param = Parameter([], I.Constant(1))
         dev = param.device()
         self.assertIs(dev, self.device)
 
@@ -61,12 +61,12 @@ class ArgumentTest(unittest.TestCase):
         g = Graph.get_default()
         self.assertIs(g, self.graph)
 
-        node = F.input([0], Shape([]))
+        node = F.raw_input([], [0])
         g = node.graph()
         self.assertIs(g, self.graph)
 
     def test_tensor_instance(self):
-        param = Parameter(Shape([]), [0])
+        param = Parameter([], I.Constant(1))
         t_origin = param.gradient
         t = param.gradient
         self.assertIs(t, t_origin)

--- a/python-primitiv/tests/parameter.py
+++ b/python-primitiv/tests/parameter.py
@@ -24,7 +24,8 @@ class ParameterTest(unittest.TestCase):
     def setUp(self):
         self.dev = D.Naive()
         Device.set_default(self.dev)
-        self.p = Parameter(initializer=np.array([1, 2, 3, 4, 5, 6, 7, 8]))
+        self.p = Parameter([8], I.Constant(0))
+        self.p.value.reset_by_vector([1, 2, 3, 4, 5, 6, 7, 8])
 
     def tearDown(self):
          pass

--- a/python-primitiv/tests/python_trainer.py
+++ b/python-primitiv/tests/python_trainer.py
@@ -95,7 +95,7 @@ def train_func(trainer):
 
     for i in range(10):
         g.clear()
-        x = F.input(input_data, Shape([2], 4))
+        x = F.raw_input(Shape([2], 4), input_data)
         w1 = F.parameter(pw1)
         b1 = F.parameter(pb1)
         w2 = F.parameter(pw2)
@@ -103,7 +103,7 @@ def train_func(trainer):
         h = F.tanh(w1 @ x + b1)
         y = w2 @ h + b2
 
-        t = F.input(output_data, Shape([], 4))
+        t = F.raw_input(Shape([], 4), output_data)
         diff = t - y
         loss = F.batch.mean(diff * diff)
 
@@ -189,7 +189,7 @@ class PythonTrainerTest(unittest.TestCase):
         dev = D.Naive()
         Device.set_default(dev)
         trainer = ExceptionTrainer()
-        p = Parameter(Shape([]), [0])
+        p = Parameter()
         with self.assertRaises(TestException) as ctx:
             trainer.add_parameter(p)
         self.assertEqual(str(ctx.exception), "configure_parameter")
@@ -211,7 +211,7 @@ class PythonTrainerTest(unittest.TestCase):
         dev = D.Naive()
         Device.set_default(dev)
         trainer = IncompleteTrainer()
-        p = Parameter(Shape([]), [0])
+        p = Parameter()
         with self.assertRaises(NotImplementedError):
             trainer.add_parameter(p)
         with self.assertRaises(NotImplementedError):


### PR DESCRIPTION
Related to #57 and #70 

This branch contains some modifications and a fix of `Parameter.init()` and `operators.input()`.

1. These functions does not take a list no longer in Python.
2. New function `operators.raw_input()` takes a list.
3. `Parameter.init()` takes only a pair of `Shape` and `Initializer`.