### PR TITLE
Changed integer types.

### DIFF
--- a/primitiv/cuda_device.h
+++ b/primitiv/cuda_device.h
@@ -21,7 +21,7 @@ public:
   /** Retrieves the number of active hardwares.
    * @return Number of active hardwares.
    */
-  static unsigned num_devices();
+  static std::uint32_t num_devices();
 
   /**
    * Creates a new CUDA device.
@@ -29,14 +29,14 @@ public:
    * @remarks The random number generator is initialized using
    *          `std::random_device`.
    */
-  explicit CUDA(unsigned device_id);
+  explicit CUDA(std::uint32_t device_id);
 
   /**
    * Creates a new CUDA device.
    * @param device_id ID of the physical GPU.
    * @param rng_seed The seed value of the random number generator.
    */
-  CUDA(unsigned device_id, unsigned rng_seed);
+  CUDA(std::uint32_t device_id, std::uint32_t rng_seed);
 
   ~CUDA() override;
 
@@ -47,8 +47,8 @@ private:
   std::shared_ptr<void> new_handle(const Shape &shape) override;
 
   std::vector<float> tensor_to_vector_impl(const Tensor &x) override;
-  std::vector<unsigned> argmax_impl(const Tensor &x, unsigned dim) override;
-  std::vector<unsigned> argmin_impl(const Tensor &x, unsigned dim) override;
+  std::vector<std::uint32_t> argmax_impl(const Tensor &x, std::uint32_t dim) override;
+  std::vector<std::uint32_t> argmin_impl(const Tensor &x, std::uint32_t dim) override;
 
   void reset_tensor_impl(float k, Tensor &x) override;
   void reset_tensor_by_array_impl(const float values[], Tensor &x) override;
@@ -62,12 +62,12 @@ private:
   void random_normal_impl(float mean, float sd, Tensor &y) override;
   void random_log_normal_impl(float mean, float sd, Tensor &y) override;
 
-  void pick_fw_impl(const Tensor &x, const std::vector<unsigned> &ids, unsigned dim, Tensor &y) override;
-  void slice_fw_impl(const Tensor &x, unsigned dim, unsigned offset, Tensor &y) override;
-  void concat_fw_impl(const std::vector<const Tensor *> &xs, unsigned dim, Tensor &y) override;
+  void pick_fw_impl(const Tensor &x, const std::vector<std::uint32_t> &ids, std::uint32_t dim, Tensor &y) override;
+  void slice_fw_impl(const Tensor &x, std::uint32_t dim, std::uint32_t offset, Tensor &y) override;
+  void concat_fw_impl(const std::vector<const Tensor *> &xs, std::uint32_t dim, Tensor &y) override;
 
-  void pick_bw_impl(const Tensor &gy, const std::vector<unsigned> &ids, unsigned dim, Tensor &gx) override;
-  void slice_bw_impl(const Tensor &gy, unsigned dim, unsigned offset, Tensor &gx) override;
+  void pick_bw_impl(const Tensor &gy, const std::vector<std::uint32_t> &ids, std::uint32_t dim, Tensor &gx) override;
+  void slice_bw_impl(const Tensor &gy, std::uint32_t dim, std::uint32_t offset, Tensor &gx) override;
 
   void negate_fw_impl(const Tensor &x, Tensor &y) override;
   void sqrt_fw_impl(const Tensor &x, Tensor &y) override;
@@ -139,9 +139,9 @@ private:
       const Tensor &a, const Tensor &b, const Tensor &y, const Tensor &gy,
       Tensor &ga, Tensor &gb) override;
 
-  void sum_fw_impl(const Tensor &x, unsigned dim, Tensor &y) override;
-  void logsumexp_fw_impl(const Tensor &x, unsigned dim, Tensor &y) override;
-  void broadcast_fw_impl(const Tensor &x, unsigned dim, unsigned size, Tensor &y) override;
+  void sum_fw_impl(const Tensor &x, std::uint32_t dim, Tensor &y) override;
+  void logsumexp_fw_impl(const Tensor &x, std::uint32_t dim, Tensor &y) override;
+  void broadcast_fw_impl(const Tensor &x, std::uint32_t dim, std::uint32_t size, Tensor &y) override;
   void batch_sum_fw_impl(const Tensor &x, Tensor &y) override;
 
   void inplace_multiply_const_impl(float k, Tensor &x) override;
@@ -150,12 +150,12 @@ private:
   void inplace_subtract_impl(const Tensor &x, Tensor &y) override;
 
 private:
-  unsigned dev_id_;
-  unsigned rng_seed_;
-  unsigned dim1_x_;
-  unsigned dim2_x_;
-  unsigned dim2_y_;
-  unsigned max_batch_;
+  std::uint32_t dev_id_;
+  std::uint32_t rng_seed_;
+  std::uint32_t dim1_x_;
+  std::uint32_t dim2_x_;
+  std::uint32_t dim2_y_;
+  std::uint32_t max_batch_;
   CUDAMemoryPool pool_;
   std::unique_ptr<CUDAInternalState> state_;
 

--- a/primitiv/cuda_memory_pool.cu
+++ b/primitiv/cuda_memory_pool.cu
@@ -11,10 +11,10 @@ using std::make_pair;
 
 namespace primitiv {
 
-std::uint64_t CUDAMemoryPool::next_pool_id_ = 0;
-std::unordered_map<std::uint64_t, CUDAMemoryPool *> CUDAMemoryPool::pools_;
+std::size_t CUDAMemoryPool::next_pool_id_ = 0;
+std::unordered_map<std::size_t, CUDAMemoryPool *> CUDAMemoryPool::pools_;
 
-CUDAMemoryPool::CUDAMemoryPool(unsigned device_id)
+CUDAMemoryPool::CUDAMemoryPool(std::uint32_t device_id)
 : pool_id_(next_pool_id_++)
 , dev_id_(device_id)
 , reserved_(64)
@@ -22,7 +22,7 @@ CUDAMemoryPool::CUDAMemoryPool(unsigned device_id)
   // Retrieves device properties.
   int max_devs;
   CUDA_CALL(::cudaGetDeviceCount(&max_devs));
-  if (dev_id_ >= static_cast<unsigned>(max_devs)) {
+  if (dev_id_ >= static_cast<std::uint32_t>(max_devs)) {
     THROW_ERROR(
         "Invalid CUDA device ID. given: " << dev_id_
         << " >= #devices: " << max_devs);
@@ -45,9 +45,9 @@ CUDAMemoryPool::~CUDAMemoryPool() {
   release_reserved_blocks();
 }
 
-std::shared_ptr<void> CUDAMemoryPool::allocate(std::uint64_t size) {
-  static const unsigned MAX_SCALE = 63;
-  unsigned scale = 0;
+std::shared_ptr<void> CUDAMemoryPool::allocate(std::size_t size) {
+  static const std::uint32_t MAX_SCALE = 63;
+  std::uint32_t scale = 0;
   while (1ull << scale < size) {
     if (scale == MAX_SCALE) {
       THROW_ERROR(
@@ -77,7 +77,7 @@ std::shared_ptr<void> CUDAMemoryPool::allocate(std::uint64_t size) {
   return std::shared_ptr<void>(ptr, CUDAMemoryDeleter(pool_id_));
 }
 
-void CUDAMemoryPool::free(std::uint64_t pool_id, void *ptr) {
+void CUDAMemoryPool::free(std::size_t pool_id, void *ptr) {
   auto it = pools_.find(pool_id);
   if (it != pools_.end()) {
     // Found a corresponding pool object, delete ptr.

--- a/primitiv/cuda_memory_pool.h
+++ b/primitiv/cuda_memory_pool.h
@@ -1,6 +1,7 @@
 #ifndef PRIMITIV_CUDA_MEMORY_POOL_H_
 #define PRIMITIV_CUDA_MEMORY_POOL_H_
 
+#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <unordered_map>
@@ -25,7 +26,7 @@ public:
    * Creates a memory pool.
    * @param device_id CUDA Device ID on which memories are stored.
    */
-  explicit CUDAMemoryPool(unsigned device_id);
+  explicit CUDAMemoryPool(std::uint32_t device_id);
 
   ~CUDAMemoryPool();
 
@@ -34,13 +35,13 @@ public:
    * @param size Size of the resulting memory.
    * @return Shared pointer of the allocated memory.
    */
-  std::shared_ptr<void> allocate(std::uint64_t size);
+  std::shared_ptr<void> allocate(std::size_t size);
 
   /**
    * Retrieves pool ID.
    * @return pool ID.
    */
-  std::uint64_t get_pool_id() const { return pool_id_; }
+  std::size_t get_pool_id() const { return pool_id_; }
 
 private:
   /**
@@ -48,7 +49,7 @@ private:
    * @param pool_id ID of the CUDAMemoryPool.
    * @param ptr Handle of the memory to be disposed.
    */
-  static void free(std::uint64_t pool_id, void *ptr);
+  static void free(std::size_t pool_id, void *ptr);
 
   /**
    * Disposes the memory managed by this pool.
@@ -61,13 +62,13 @@ private:
    */
   void release_reserved_blocks();
 
-  static std::uint64_t next_pool_id_;
-  static std::unordered_map<std::uint64_t, CUDAMemoryPool *> pools_;
+  static std::size_t next_pool_id_;
+  static std::unordered_map<std::size_t, CUDAMemoryPool *> pools_;
 
-  std::uint64_t pool_id_;
-  unsigned dev_id_;
+  std::size_t pool_id_;
+  std::uint32_t dev_id_;
   std::vector<std::vector<void *>> reserved_;
-  std::unordered_map<void *, unsigned> supplied_;
+  std::unordered_map<void *, std::uint32_t> supplied_;
 };
 
 /**
@@ -76,10 +77,10 @@ private:
 class CUDAMemoryDeleter {
   CUDAMemoryDeleter() = delete;
 public:
-  explicit CUDAMemoryDeleter(std::uint64_t pool_id) : pool_id_(pool_id) {}
+  explicit CUDAMemoryDeleter(std::size_t pool_id) : pool_id_(pool_id) {}
   void operator()(void *ptr) { CUDAMemoryPool::free(pool_id_, ptr); }
 private:
-  std::uint64_t pool_id_;
+  std::size_t pool_id_;
 };
 
 }  // namespace primitiv

--- a/primitiv/device.cc
+++ b/primitiv/device.cc
@@ -54,12 +54,12 @@ vector<float> Device::tensor_to_vector(const Tensor &x) {
   return tensor_to_vector_impl(x);
 }
 
-vector<unsigned> Device::argmax(const Tensor &x, unsigned dim) {
+vector<std::uint32_t> Device::argmax(const Tensor &x, std::uint32_t dim) {
   CHECK_DEVICE(x);
   return argmax_impl(x, dim);
 }
 
-vector<unsigned> Device::argmin(const Tensor &x, unsigned dim) {
+vector<std::uint32_t> Device::argmin(const Tensor &x, std::uint32_t dim) {
   CHECK_DEVICE(x);
   return argmin_impl(x, dim);
 }
@@ -96,7 +96,7 @@ Tensor Device::copy_tensor(const Tensor &x) {
   return y;
 }
 
-Tensor Device::identity(unsigned size) {
+Tensor Device::identity(std::uint32_t size) {
   if (size == 0) {
     THROW_ERROR("Invalid size of the identity matrix: " << size);
   }
@@ -149,7 +149,7 @@ Tensor Device::random_log_normal(const Shape &shape, float mean, float sd) {
 }
 
 Tensor Device::pick_fw(
-    const Tensor &x, const vector<unsigned> &ids, unsigned dim) {
+    const Tensor &x, const vector<std::uint32_t> &ids, std::uint32_t dim) {
   CHECK_DEVICE(x);
   Tensor y = new_raw_tensor(shape_ops::pick(x.shape(), ids, dim));
   pick_fw_impl(x, ids, dim, y);
@@ -157,17 +157,17 @@ Tensor Device::pick_fw(
 }
 
 Tensor Device::slice_fw(
-    const Tensor &x, unsigned dim, unsigned lower, unsigned upper) {
+    const Tensor &x, std::uint32_t dim, std::uint32_t lower, std::uint32_t upper) {
   CHECK_DEVICE(x);
   Tensor y = new_raw_tensor(shape_ops::slice(x.shape(), dim, lower, upper));
   slice_fw_impl(x, dim, lower, y);
   return y;
 }
 
-Tensor Device::concat_fw(const vector<const Tensor *> &xs, unsigned dim) {
+Tensor Device::concat_fw(const vector<const Tensor *> &xs, std::uint32_t dim) {
   if (xs.empty()) THROW_ERROR("No tensors to concat.");
   vector<const Shape *> shapes(xs.size());
-  for (unsigned i = 0; i < xs.size(); ++i) {
+  for (std::uint32_t i = 0; i < xs.size(); ++i) {
     CHECK_DEVICE(*xs[i]);
     shapes[i] = &xs[i]->shape();
   }
@@ -177,7 +177,7 @@ Tensor Device::concat_fw(const vector<const Tensor *> &xs, unsigned dim) {
 }
 
 void Device::pick_bw(
-    const Tensor &gy, const std::vector<unsigned> &ids, unsigned dim,
+    const Tensor &gy, const std::vector<std::uint32_t> &ids, std::uint32_t dim,
     Tensor &gx) {
   CHECK_DEVICE(gy);
   CHECK_DEVICE(gx);
@@ -191,7 +191,7 @@ void Device::pick_bw(
 }
 
 void Device::slice_bw(
-    const Tensor &gy, unsigned dim, unsigned offset, Tensor &gx) {
+    const Tensor &gy, std::uint32_t dim, std::uint32_t offset, Tensor &gx) {
   CHECK_DEVICE(gy);
   CHECK_DEVICE(gx);
   const Shape &sy = gy.shape();
@@ -364,21 +364,21 @@ DEV_BW_AB(matmul, shape_ops::matmul);
 #undef DEV_FW_AB
 #undef DEV_BW_AB
 
-Tensor Device::sum_fw(const Tensor &x, unsigned dim) {
+Tensor Device::sum_fw(const Tensor &x, std::uint32_t dim) {
   CHECK_DEVICE(x);
   Tensor y = new_raw_tensor(x.shape().resize_dim(dim, 1));
   sum_fw_impl(x, dim, y);
   return y;
 }
 
-Tensor Device::logsumexp_fw(const Tensor &x, unsigned dim) {
+Tensor Device::logsumexp_fw(const Tensor &x, std::uint32_t dim) {
   CHECK_DEVICE(x);
   Tensor y = new_raw_tensor(x.shape().resize_dim(dim, 1));
   logsumexp_fw_impl(x, dim, y);
   return y;
 }
 
-Tensor Device::broadcast_fw(const Tensor &x, unsigned dim, unsigned size) {
+Tensor Device::broadcast_fw(const Tensor &x, std::uint32_t dim, std::uint32_t size) {
   CHECK_DEVICE(x);
   Tensor y = new_raw_tensor(shape_ops::broadcast(x.shape(), dim, size));
   broadcast_fw_impl(x, dim, size, y);

--- a/primitiv/device.h
+++ b/primitiv/device.h
@@ -1,6 +1,7 @@
 #ifndef PRIMITIV_DEVICE_H_
 #define PRIMITIV_DEVICE_H_
 
+#include <cstdint>
 #include <memory>
 #include <primitiv/mixins.h>
 #include <primitiv/shape.h>
@@ -84,7 +85,7 @@ public:
   Tensor copy_tensor(const Tensor &x);
 
   // Provides an identity matrix.
-  Tensor identity(unsigned size);
+  Tensor identity(std::uint32_t size);
 
   // Random value generators.
   Tensor random_bernoulli(const Shape &shape, float p);
@@ -93,12 +94,12 @@ public:
   Tensor random_log_normal(const Shape &shape, float mean, float sd);
 
   // Tensor manipulations.
-  Tensor pick_fw(const Tensor &x, const std::vector<unsigned> &ids, unsigned dim);
-  Tensor slice_fw(const Tensor &x, unsigned dim, unsigned lower, unsigned upper);
-  Tensor concat_fw(const std::vector<const Tensor *> &xs, unsigned dim);
+  Tensor pick_fw(const Tensor &x, const std::vector<std::uint32_t> &ids, std::uint32_t dim);
+  Tensor slice_fw(const Tensor &x, std::uint32_t dim, std::uint32_t lower, std::uint32_t upper);
+  Tensor concat_fw(const std::vector<const Tensor *> &xs, std::uint32_t dim);
 
-  void pick_bw(const Tensor &gy, const std::vector<unsigned> &ids, unsigned dim, Tensor &gx);
-  void slice_bw(const Tensor &gy, unsigned dim, unsigned offset, Tensor &gx);
+  void pick_bw(const Tensor &gy, const std::vector<std::uint32_t> &ids, std::uint32_t dim, Tensor &gx);
+  void slice_bw(const Tensor &gy, std::uint32_t dim, std::uint32_t offset, Tensor &gx);
 
   // Unary operations.
   Tensor negate_fw(const Tensor &x);
@@ -175,9 +176,9 @@ public:
       Tensor &ga, Tensor &gb);
 
   // Dimension operations.
-  Tensor sum_fw(const Tensor &x, unsigned dim);
-  Tensor logsumexp_fw(const Tensor &x, unsigned dim);
-  Tensor broadcast_fw(const Tensor &x, unsigned dim, unsigned size);
+  Tensor sum_fw(const Tensor &x, std::uint32_t dim);
+  Tensor logsumexp_fw(const Tensor &x, std::uint32_t dim);
+  Tensor broadcast_fw(const Tensor &x, std::uint32_t dim, std::uint32_t size);
   Tensor batch_sum_fw(const Tensor &x);
 
   /**
@@ -225,7 +226,7 @@ private:
    * @param dim A specified axis.
    * @return A list of integers that indicates positions of the maximum values.
    */
-  std::vector<unsigned> argmax(const Tensor &x, unsigned dim);
+  std::vector<std::uint32_t> argmax(const Tensor &x, std::uint32_t dim);
 
   /**
    * Retrieves argmin indices along an axis.
@@ -233,7 +234,7 @@ private:
    * @param dim A specified axis.
    * @return A list of integers that indicates positions of the minimum values.
    */
-  std::vector<unsigned> argmin(const Tensor &x, unsigned dim);
+  std::vector<std::uint32_t> argmin(const Tensor &x, std::uint32_t dim);
 
 protected:
   /**
@@ -269,8 +270,8 @@ private:
   virtual std::shared_ptr<void> new_handle(const Shape &shape) = 0;
 
   virtual std::vector<float> tensor_to_vector_impl(const Tensor &x) = 0;
-  virtual std::vector<unsigned> argmax_impl(const Tensor &x, unsigned dim) = 0;
-  virtual std::vector<unsigned> argmin_impl(const Tensor &x, unsigned dim) = 0;
+  virtual std::vector<std::uint32_t> argmax_impl(const Tensor &x, std::uint32_t dim) = 0;
+  virtual std::vector<std::uint32_t> argmin_impl(const Tensor &x, std::uint32_t dim) = 0;
 
   virtual void reset_tensor_impl(float k, Tensor &x) = 0;
   virtual void reset_tensor_by_array_impl(const float values[], Tensor &x) = 0;
@@ -284,12 +285,12 @@ private:
   virtual void random_normal_impl(float mean, float sd, Tensor &y) = 0;
   virtual void random_log_normal_impl(float mean, float sd, Tensor &y) = 0;
 
-  virtual void pick_fw_impl(const Tensor &x, const std::vector<unsigned> &ids, unsigned dim, Tensor &y) = 0;
-  virtual void slice_fw_impl(const Tensor &x, unsigned dim, unsigned offset, Tensor &y) = 0;
-  virtual void concat_fw_impl(const std::vector<const Tensor *> &xs, unsigned dim, Tensor &y) = 0;
+  virtual void pick_fw_impl(const Tensor &x, const std::vector<std::uint32_t> &ids, std::uint32_t dim, Tensor &y) = 0;
+  virtual void slice_fw_impl(const Tensor &x, std::uint32_t dim, std::uint32_t offset, Tensor &y) = 0;
+  virtual void concat_fw_impl(const std::vector<const Tensor *> &xs, std::uint32_t dim, Tensor &y) = 0;
 
-  virtual void pick_bw_impl(const Tensor &gy, const std::vector<unsigned> &ids, unsigned dim, Tensor &gx) = 0;
-  virtual void slice_bw_impl(const Tensor &gy, unsigned dim, unsigned offset, Tensor &gx) = 0;
+  virtual void pick_bw_impl(const Tensor &gy, const std::vector<std::uint32_t> &ids, std::uint32_t dim, Tensor &gx) = 0;
+  virtual void slice_bw_impl(const Tensor &gy, std::uint32_t dim, std::uint32_t offset, Tensor &gx) = 0;
 
   virtual void negate_fw_impl(const Tensor &x, Tensor &y) = 0;
   virtual void sqrt_fw_impl(const Tensor &x, Tensor &y) = 0;
@@ -361,9 +362,9 @@ private:
       const Tensor &a, const Tensor &b, const Tensor &y, const Tensor &gy,
       Tensor &ga, Tensor &gb) = 0;
 
-  virtual void sum_fw_impl(const Tensor &x, unsigned dim, Tensor &y) = 0;
-  virtual void logsumexp_fw_impl(const Tensor &x, unsigned dim, Tensor &y) = 0;
-  virtual void broadcast_fw_impl(const Tensor &x, unsigned dim, unsigned size, Tensor &y) = 0;
+  virtual void sum_fw_impl(const Tensor &x, std::uint32_t dim, Tensor &y) = 0;
+  virtual void logsumexp_fw_impl(const Tensor &x, std::uint32_t dim, Tensor &y) = 0;
+  virtual void broadcast_fw_impl(const Tensor &x, std::uint32_t dim, std::uint32_t size, Tensor &y) = 0;
   virtual void batch_sum_fw_impl(const Tensor &x, Tensor &y) = 0;
 
   virtual void inplace_multiply_const_impl(float k, Tensor &x) = 0;

--- a/primitiv/error.h
+++ b/primitiv/error.h
@@ -1,6 +1,7 @@
 #ifndef PRIMITIV_ERROR_H_
 #define PRIMITIV_ERROR_H_
 
+#include <cstdint>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -14,7 +15,7 @@ class Error : public std::exception {
   Error() = delete;
 
 public:
-  Error(const std::string &file, unsigned line, const std::string &message)
+  Error(const std::string &file, std::uint32_t line, const std::string &message)
   : file_(file), line_(line), msg_(message) {
     std::stringstream ss;
     ss << file_ << ": " << line_ << ": " << msg_;
@@ -25,7 +26,7 @@ public:
 
 private:
   std::string file_;
-  unsigned line_;
+  std::uint32_t line_;
   std::string msg_;
   std::string full_msg_;
 };

--- a/primitiv/function_impl.cc
+++ b/primitiv/function_impl.cc
@@ -221,9 +221,9 @@ Tensor Concat::forward(const std::vector<const Tensor *> &args) {
 void Concat::backward(
     const Tensor &y, const Tensor &gy,
     const vector<const Tensor *> &x, const vector<Tensor *> &gx) const {
-  unsigned offset = 0;
+  std::uint32_t offset = 0;
   for (Tensor *gxi : gx) {
-    const unsigned span = gxi->shape()[dim_];
+    const std::uint32_t span = gxi->shape()[dim_];
     *gxi += operators::slice(gy, dim_, offset, offset + span);
     offset += span;
   }
@@ -471,7 +471,7 @@ BACKWARD(MatrixMultiply) { gy.device().matmul_bw(*x[0], *x[1], y, gy, *gx[0], *g
 BACKWARD(Sum) { *gx[0] += operators::broadcast(gy, dim_, x[0]->shape()[dim_]); }
 BACKWARD(LogSumExp) {
   // NOTE(odashi): dy/dx = softmax(x) = exp(x - y)
-  const unsigned n = x[0]->shape()[dim_];
+  const std::uint32_t n = x[0]->shape()[dim_];
   *gx[0] +=
     operators::exp(*x[0] - operators::broadcast(y, dim_, n)) * operators::broadcast(gy, dim_, n);
 }

--- a/primitiv/function_impl.h
+++ b/primitiv/function_impl.h
@@ -1,6 +1,7 @@
 #ifndef PRIMITIV_FUNCTION_IMPL_H_
 #define PRIMITIV_FUNCTION_IMPL_H_
 
+#include <cstdint>
 #include <primitiv/function.h>
 #include <primitiv/parameter.h>
 #include <primitiv/shape.h>
@@ -77,14 +78,14 @@ private:
 class IdentityMatrix : public primitiv::Function {
   NO_CTOR_CLASS_DECL(IdentityMatrix);
 public:
-  IdentityMatrix(unsigned size, Device &device)
+  IdentityMatrix(std::uint32_t size, Device &device)
     : size_(size), device_(device) {}
   Device *get_device() const override { return &device_; }
   std::string name() const override {
     return "IdentityMatrix(" + std::to_string(size_) + ')';
   }
 private:
-  unsigned size_;
+  std::uint32_t size_;
   Device &device_;
 };
 
@@ -160,40 +161,40 @@ private:
 class Pick : public primitiv::Function {
   NO_CTOR_CLASS_DECL(Pick);
 public:
-  Pick(const std::vector<unsigned> &ids, unsigned dim)
+  Pick(const std::vector<std::uint32_t> &ids, std::uint32_t dim)
     : ids_(ids), dim_(dim) {}
   std::string name() const override {
     return "Pick(" + std::to_string(dim_) + ')';
   };
 private:
-  std::vector<unsigned> ids_;
-  unsigned dim_;
+  std::vector<std::uint32_t> ids_;
+  std::uint32_t dim_;
 };
 
 class Slice : public primitiv::Function {
   NO_CTOR_CLASS_DECL(Slice);
 public:
-  Slice(unsigned dim, unsigned lower, unsigned upper)
+  Slice(std::uint32_t dim, std::uint32_t lower, std::uint32_t upper)
     : dim_(dim), lower_(lower), upper_(upper) {}
   std::string name() const override {
     return "Slice(" + std::to_string(dim_) +
       ',' + std::to_string(lower_) + ':' + std::to_string(upper_) + ')';
   }
 private:
-  unsigned dim_;
-  unsigned lower_;
-  unsigned upper_;
+  std::uint32_t dim_;
+  std::uint32_t lower_;
+  std::uint32_t upper_;
 };
 
 class Concat : public primitiv::Function {
   NO_CTOR_CLASS_DECL(Concat);
 public:
-  Concat(unsigned dim) : dim_(dim) {}
+  Concat(std::uint32_t dim) : dim_(dim) {}
   std::string name() const override {
     return "Concat(" + std::to_string(dim_) + ')';
   }
 private:
-  unsigned dim_;
+  std::uint32_t dim_;
 };
 
 class Reshape : public primitiv::Function {
@@ -210,60 +211,60 @@ private:
 class Sum : public Function {
   NO_CTOR_CLASS_DECL(Sum);
 public:
-  explicit Sum(unsigned dim) : dim_(dim) {}
+  explicit Sum(std::uint32_t dim) : dim_(dim) {}
   std::string name() const override {
     return "Sum(" + std::to_string(dim_) + ')';
   }
 private:
-  unsigned dim_;
+  std::uint32_t dim_;
 };
 
 class LogSumExp : public Function {
   NO_CTOR_CLASS_DECL(LogSumExp);
 public:
-  explicit LogSumExp(unsigned dim) : dim_(dim) {}
+  explicit LogSumExp(std::uint32_t dim) : dim_(dim) {}
   std::string name() const override {
     return "LogSumExp(" + std::to_string(dim_) + ')';
   }
 private:
-  unsigned dim_;
+  std::uint32_t dim_;
 };
 
 class Broadcast : public Function {
   NO_CTOR_CLASS_DECL(Broadcast);
 public:
-  Broadcast(unsigned dim, unsigned size) : dim_(dim), size_(size) {}
+  Broadcast(std::uint32_t dim, std::uint32_t size) : dim_(dim), size_(size) {}
   std::string name() const override {
     return "Broadcast(" + std::to_string(dim_)
       + ',' + std::to_string(size_) + ')';
   }
 private:
-  unsigned dim_;
-  unsigned size_;
+  std::uint32_t dim_;
+  std::uint32_t size_;
 };
 
 class SoftmaxCrossEntropy : public Function {
   NO_CTOR_CLASS_DECL(SoftmaxCrossEntropy);
 public:
-  explicit SoftmaxCrossEntropy(unsigned dim) : dim_(dim) {}
+  explicit SoftmaxCrossEntropy(std::uint32_t dim) : dim_(dim) {}
   std::string name() const override {
     return "SoftmaxCrossEntropy(" + std::to_string(dim_) + ')';
   }
 private:
-  unsigned dim_;
+  std::uint32_t dim_;
 };
 
 class SparseSoftmaxCrossEntropy : public Function {
   NO_CTOR_CLASS_DECL(SparseSoftmaxCrossEntropy);
 public:
   explicit SparseSoftmaxCrossEntropy(
-      const std::vector<unsigned> ids, unsigned dim) : ids_(ids), dim_(dim) {}
+      const std::vector<std::uint32_t> ids, std::uint32_t dim) : ids_(ids), dim_(dim) {}
   std::string name() const override {
     return "SparseSoftmaxCrossEntropy(" + std::to_string(dim_) + ')';
   }
 private:
-  std::vector<unsigned> ids_;
-  unsigned dim_;
+  std::vector<std::uint32_t> ids_;
+  std::uint32_t dim_;
   Tensor log_softmax_x_;  // Only used when PRIMITIV_USE_CACHE=ON
 };
 

--- a/primitiv/graph.cc
+++ b/primitiv/graph.cc
@@ -63,7 +63,7 @@ Node Graph::add_function(
   // Gathers information of args.
   vector<Address> arg_addrs(args.size());
   vector<const Shape *> arg_shapes(args.size());
-  for (unsigned i = 0; i < args.size(); ++i) {
+  for (std::uint32_t i = 0; i < args.size(); ++i) {
     const Node &arg = args[i];
     CHECK_NODE(arg);
     arg_addrs[i] = { arg.fid_, arg.vid_ };
@@ -89,11 +89,11 @@ Node Graph::add_function(
   // Makes nodes of return values.
   vector<NodeInfo> rets;
   rets.emplace_back(NodeInfo {
-      move(ret_shape), *ret_device, Tensor(), Tensor(), vector<unsigned>(),
+      move(ret_shape), *ret_device, Tensor(), Tensor(), vector<std::uint32_t>(),
   });
 
   // Updates the graph.
-  const unsigned ret_fid = funcs_.size();
+  const std::uint32_t ret_fid = funcs_.size();
   for (const Address &arg_addr : arg_addrs) {
     funcs_[arg_addr.fid].rets[arg_addr.vid].sinks.emplace_back(ret_fid);
   }
@@ -105,8 +105,8 @@ Node Graph::add_function(
 const Tensor &Graph::forward(const Node &node) {
   CHECK_NODE(node);
 
-  std::function<const Tensor *(unsigned)> forward_recursive = [&](
-      unsigned fid) -> const Tensor * {
+  std::function<const Tensor *(std::uint32_t)> forward_recursive = [&](
+      std::uint32_t fid) -> const Tensor * {
     FunctionInfo &cur_f = funcs_[fid];
     NodeInfo &cur_n = cur_f.rets[0];
 
@@ -160,7 +160,7 @@ void Graph::backward(const Node &node) {
   // NOTE(odashi):
   // In the current implementation, the node ID corresponds to the inverse
   // topological order of the computation graph.
-  for (int fid = node.fid_; fid >= 0; --fid) {
+  for (std::int32_t fid = node.fid_; fid >= 0; --fid) {
     FunctionInfo &cur_f = funcs_[fid];
     NodeInfo &cur_n = cur_f.rets[0];
     const Tensor *cur_v = cur_n.value.valid()
@@ -171,12 +171,12 @@ void Graph::backward(const Node &node) {
     if (!cur_n.grad.valid()) continue;
 
     // Gathers argument value/gradient tensors.
-    const unsigned arg_size = cur_f.args.size();
+    const std::uint32_t arg_size = cur_f.args.size();
     vector<const Tensor *> arg_values;
     vector<Tensor *> arg_grads;
     arg_values.reserve(arg_size);
     arg_grads.reserve(arg_size);
-    for (unsigned i = 0; i < arg_size; ++i) {
+    for (std::uint32_t i = 0; i < arg_size; ++i) {
       const Address &arg = cur_f.args[i];
       FunctionInfo &arg_f = funcs_[arg.fid];
       NodeInfo &arg_n = arg_f.rets[arg.vid];
@@ -227,14 +227,14 @@ std::string Graph::dump(const std::string &format) const {
     fontname = "Courier",
   ];)";
 
-  for (unsigned i = 0; i < funcs_.size(); ++i) {
+  for (std::uint32_t i = 0; i < funcs_.size(); ++i) {
     const FunctionInfo &f = funcs_[i];
     ss << "  " << i << " [label = \"" << f.func->name() << "\"];\n";
   }
 
-  for (unsigned i = 0; i < funcs_.size(); ++i) {
+  for (std::uint32_t i = 0; i < funcs_.size(); ++i) {
     const FunctionInfo &f = funcs_[i];
-    for (unsigned j = 0; j < f.args.size(); ++j) {
+    for (std::uint32_t j = 0; j < f.args.size(); ++j) {
       const Shape &s = funcs_[f.args[j].fid].rets[f.args[j].vid].shape;
       ss << "  "
          << f.args[j].fid << " -> " << i

--- a/primitiv/graph.h
+++ b/primitiv/graph.h
@@ -1,6 +1,7 @@
 #ifndef PRIMITIV_GRAPH_H_
 #define PRIMITIV_GRAPH_H_
 
+#include <cstdint>
 #include <memory>
 #include <vector>
 #include <primitiv/function.h>
@@ -59,7 +60,7 @@ public:
    * Returns the function ID.
    * @return Function ID.
    */
-  unsigned function_id() const {
+  std::uint32_t function_id() const {
     if (!valid()) THROW_ERROR("Invalid node.");
     return fid_;
   }
@@ -68,7 +69,7 @@ public:
    * Returns the value ID of the function.
    * @return Value ID.
    */
-  unsigned value_id() const {
+  std::uint32_t value_id() const {
     if (!valid()) THROW_ERROR("Invalid node.");
     return vid_;
   }
@@ -106,14 +107,14 @@ public:
    * @param dim A specified axis.
    * @return A list of integers that indicates positions of the maximum values.
    */
-  std::vector<unsigned> argmax(unsigned dim) const;
+  std::vector<std::uint32_t> argmax(std::uint32_t dim) const;
 
   /**
    * Returns argmin indices along an axis of this node.
    * @param dim A specified axis.
    * @return A list of integers that indicates positions of the minimum values.
    */
-  std::vector<unsigned> argmin(unsigned dim) const;
+  std::vector<std::uint32_t> argmin(std::uint32_t dim) const;
 
   /**
    * Executes the backward operation from this node.
@@ -127,11 +128,11 @@ private:
    * @param fid Function ID.
    * @param vid Value ID.
    */
-  Node(Graph &g, unsigned fid, unsigned vid) : g_(&g), fid_(fid), vid_(vid) {}
+  Node(Graph &g, std::uint32_t fid, std::uint32_t vid) : g_(&g), fid_(fid), vid_(vid) {}
 
   Graph *g_;
-  unsigned fid_;
-  unsigned vid_;
+  std::uint32_t fid_;
+  std::uint32_t vid_;
 };
 
 /**
@@ -207,15 +208,15 @@ public:
    * Returns the number of functions in the computation graph.
    * @return Number of nodes.
    */
-  unsigned num_functions() const { return funcs_.size(); }
+  std::uint32_t num_functions() const { return funcs_.size(); }
 
 private:
   /**
    * Tuple of values to determine the location of the node.
    */
   struct Address {
-    unsigned fid;
-    unsigned vid;
+    std::uint32_t fid;
+    std::uint32_t vid;
   };
 
   /**
@@ -226,7 +227,7 @@ private:
     Device &device;
     Tensor value;
     Tensor grad;
-    std::vector<unsigned> sinks;
+    std::vector<std::uint32_t> sinks;
   };
 
   /**
@@ -263,12 +264,12 @@ inline std::vector<float> Node::to_vector() const {
   return g_->forward(*this).to_vector();
 }
 
-inline std::vector<unsigned> Node::argmax(unsigned dim) const {
+inline std::vector<std::uint32_t> Node::argmax(std::uint32_t dim) const {
   if (!valid()) THROW_ERROR("Invalid node.");
   return g_->forward(*this).argmax(dim);
 }
 
-inline std::vector<unsigned> Node::argmin(unsigned dim) const {
+inline std::vector<std::uint32_t> Node::argmin(std::uint32_t dim) const {
   if (!valid()) THROW_ERROR("Invalid node.");
   return g_->forward(*this).argmin(dim);
 }

--- a/primitiv/naive_device.cc
+++ b/primitiv/naive_device.cc
@@ -20,7 +20,7 @@ void Naive::dump_description() const {
 }
 
 std::shared_ptr<void> Naive::new_handle(const Shape &shape) {
-  const unsigned mem_size = sizeof(float) * shape.size();
+  const std::uint32_t mem_size = sizeof(float) * shape.size();
   void *data = std::malloc(mem_size);
   if (!data) {
     THROW_ERROR("Memory allocation failed. Requested size: " << mem_size);
@@ -32,29 +32,29 @@ std::shared_ptr<void> Naive::new_handle(const Shape &shape) {
 #define CDATA(x) static_cast<const float *>((x).data())
 
 #define REPEAT_OP(i, n, op) \
-  for (unsigned (i) = 0; (i) < (n); ++(i)) { (op); }
+  for (std::uint32_t (i) = 0; (i) < (n); ++(i)) { (op); }
 
 std::vector<float> Naive::tensor_to_vector_impl(const Tensor &x) {
-  const unsigned num_elements = x.shape().size();
+  const std::uint32_t num_elements = x.shape().size();
   std::vector<float> ret(num_elements);
   std::memcpy(&ret[0], x.data(), sizeof(float) * num_elements);
   return ret;
 }
 
-std::vector<unsigned> Naive::argmax_impl(const Tensor &x, unsigned dim) {
+std::vector<std::uint32_t> Naive::argmax_impl(const Tensor &x, std::uint32_t dim) {
   const Shape &s = x.shape();
-  const unsigned n = s[dim];
-  const unsigned repeat = s.size() / n;
-  const unsigned skip1 = s.lower_volume(dim);
-  const unsigned skip2 = skip1 * n;
+  const std::uint32_t n = s[dim];
+  const std::uint32_t repeat = s.size() / n;
+  const std::uint32_t skip1 = s.lower_volume(dim);
+  const std::uint32_t skip2 = skip1 * n;
   const float *src = CDATA(x);
-  std::vector<unsigned> ret;
+  std::vector<std::uint32_t> ret;
   ret.reserve(repeat);
-  for (unsigned i = 0; i < repeat; ++i) {
-    unsigned offset = i % skip1 + (i / skip1) * skip2;
+  for (std::uint32_t i = 0; i < repeat; ++i) {
+    std::uint32_t offset = i % skip1 + (i / skip1) * skip2;
     float max_val = src[offset];
-    unsigned argmax_val = 0;
-    for (unsigned j = 1; j < n; ++j) {
+    std::uint32_t argmax_val = 0;
+    for (std::uint32_t j = 1; j < n; ++j) {
       offset += skip1;
       if (src[offset] > max_val) {
         max_val = src[offset];
@@ -66,20 +66,20 @@ std::vector<unsigned> Naive::argmax_impl(const Tensor &x, unsigned dim) {
   return ret;
 }
 
-std::vector<unsigned> Naive::argmin_impl(const Tensor &x, unsigned dim) {
+std::vector<std::uint32_t> Naive::argmin_impl(const Tensor &x, std::uint32_t dim) {
   const Shape &s = x.shape();
-  const unsigned n = s[dim];
-  const unsigned repeat = s.size() / n;
-  const unsigned skip1 = s.lower_volume(dim);
-  const unsigned skip2 = skip1 * n;
+  const std::uint32_t n = s[dim];
+  const std::uint32_t repeat = s.size() / n;
+  const std::uint32_t skip1 = s.lower_volume(dim);
+  const std::uint32_t skip2 = skip1 * n;
   const float *src = CDATA(x);
-  std::vector<unsigned> ret;
+  std::vector<std::uint32_t> ret;
   ret.reserve(repeat);
-  for (unsigned i = 0; i < repeat; ++i) {
-    unsigned offset = i % skip1 + (i / skip1) * skip2;
+  for (std::uint32_t i = 0; i < repeat; ++i) {
+    std::uint32_t offset = i % skip1 + (i / skip1) * skip2;
     float max_val = src[offset];
-    unsigned argmax_val = 0;
-    for (unsigned j = 1; j < n; ++j) {
+    std::uint32_t argmax_val = 0;
+    for (std::uint32_t j = 1; j < n; ++j) {
       offset += skip1;
       if (src[offset] < max_val) {
         max_val = src[offset];
@@ -93,7 +93,7 @@ std::vector<unsigned> Naive::argmin_impl(const Tensor &x, unsigned dim) {
 
 void Naive::reset_tensor_impl(float k, Tensor &x) {
   float *dest = DATA(x);
-  const unsigned size = x.shape().size();
+  const std::uint32_t size = x.shape().size();
   REPEAT_OP(i, size, dest[i] = k);
 }
 
@@ -114,22 +114,22 @@ void Naive::copy_tensor_impl(const Tensor &x, Tensor &y) {
 void Naive::identity_impl(Tensor &y) {
   reset_tensor_impl(0, y);
   float *dest = DATA(y);
-  const unsigned size = y.shape()[0];
+  const std::uint32_t size = y.shape()[0];
   REPEAT_OP(i, size, dest[i * (size + 1)] = 1);
 }
 
 void Naive::random_bernoulli_impl(float p, Tensor &y) {
   std::bernoulli_distribution dist(p);
   float *dest = DATA(y);
-  const unsigned size = y.shape().size();
+  const std::uint32_t size = y.shape().size();
   REPEAT_OP(i, size, dest[i] = dist(rng_));
 }
 
 void Naive::random_uniform_impl(float lower, float upper, Tensor &y) {
   std::uniform_real_distribution<float> dist(lower, upper);
   float *dest = DATA(y);
-  const unsigned size = y.shape().size();
-  for (unsigned i = 0; i < size; ++i) {
+  const std::uint32_t size = y.shape().size();
+  for (std::uint32_t i = 0; i < size; ++i) {
     const float x = dist(rng_);
     dest[i] = x == lower ? upper : x;
   }
@@ -138,31 +138,31 @@ void Naive::random_uniform_impl(float lower, float upper, Tensor &y) {
 void Naive::random_normal_impl(float mean, float sd, Tensor &y) {
   std::normal_distribution<float> dist(mean, sd);
   float *dest = DATA(y);
-  const unsigned size = y.shape().size();
+  const std::uint32_t size = y.shape().size();
   REPEAT_OP(i, size, dest[i] = dist(rng_));
 }
 
 void Naive::random_log_normal_impl(float mean, float sd, Tensor &y) {
   std::lognormal_distribution<float> dist(mean, sd);
   float *dest = DATA(y);
-  const unsigned size = y.shape().size();
+  const std::uint32_t size = y.shape().size();
   REPEAT_OP(i, size, dest[i] = dist(rng_));
 }
 
 void Naive::pick_fw_impl(
-    const Tensor &x, const std::vector<unsigned> &ids, unsigned dim,
+    const Tensor &x, const std::vector<std::uint32_t> &ids, std::uint32_t dim,
     Tensor &y) {
-  const unsigned bs = y.shape().batch();
-  const unsigned skip_x = x.shape().has_batch() * x.shape().volume();
-  const unsigned skip_i = ids.size() > 1;
-  const unsigned base = y.shape().lower_volume(dim);
-  const unsigned skip = base * x.shape()[dim];
-  const unsigned repeat = y.shape().volume() / base;
+  const std::uint32_t bs = y.shape().batch();
+  const std::uint32_t skip_x = x.shape().has_batch() * x.shape().volume();
+  const std::uint32_t skip_i = ids.size() > 1;
+  const std::uint32_t base = y.shape().lower_volume(dim);
+  const std::uint32_t skip = base * x.shape()[dim];
+  const std::uint32_t repeat = y.shape().volume() / base;
 
   float *dest = DATA(y);
-  for (unsigned batch = 0; batch < bs; ++batch) {
+  for (std::uint32_t batch = 0; batch < bs; ++batch) {
     const float *src = CDATA(x) + batch * skip_x + base * ids[batch * skip_i];
-    for (unsigned i = 0; i < repeat; ++i) {
+    for (std::uint32_t i = 0; i < repeat; ++i) {
       const float *sp = src;
       REPEAT_OP(j, base, *dest++ = *sp++);
       src += skip;
@@ -171,15 +171,15 @@ void Naive::pick_fw_impl(
 }
 
 void Naive::slice_fw_impl(
-    const Tensor &x, unsigned dim, unsigned offset, Tensor &y) {
-  const unsigned base = y.shape().lower_volume(dim);
-  const unsigned span = base * y.shape()[dim];
-  const unsigned skip = base * x.shape()[dim];
-  const unsigned repeat = y.shape().size() / span;
+    const Tensor &x, std::uint32_t dim, std::uint32_t offset, Tensor &y) {
+  const std::uint32_t base = y.shape().lower_volume(dim);
+  const std::uint32_t span = base * y.shape()[dim];
+  const std::uint32_t skip = base * x.shape()[dim];
+  const std::uint32_t repeat = y.shape().size() / span;
 
   float *dest = DATA(y);
   const float *src = CDATA(x) + base * offset;
-  for (unsigned i = 0; i < repeat; ++i) {
+  for (std::uint32_t i = 0; i < repeat; ++i) {
     const float *sp = src;
     REPEAT_OP(j, span, *dest++ = *sp++);
     src += skip;
@@ -187,22 +187,22 @@ void Naive::slice_fw_impl(
 }
 
 void Naive::concat_fw_impl(
-    const std::vector<const Tensor *> &xs, unsigned dim, Tensor &y) {
-  const unsigned new_bs = y.shape().batch();
-  const unsigned base = y.shape().lower_volume(dim);
-  const unsigned skip = base * y.shape()[dim];
-  const unsigned repeat = y.shape().volume() / skip;
+    const std::vector<const Tensor *> &xs, std::uint32_t dim, Tensor &y) {
+  const std::uint32_t new_bs = y.shape().batch();
+  const std::uint32_t base = y.shape().lower_volume(dim);
+  const std::uint32_t skip = base * y.shape()[dim];
+  const std::uint32_t repeat = y.shape().volume() / skip;
 
-  unsigned offset = 0;
+  std::uint32_t offset = 0;
   for (const Tensor *x : xs) {
-    const unsigned src_dim = x->shape()[dim];
-    const unsigned span = base * src_dim;
-    const unsigned b_skip = x->shape().has_batch() * span * repeat;
+    const std::uint32_t src_dim = x->shape()[dim];
+    const std::uint32_t span = base * src_dim;
+    const std::uint32_t b_skip = x->shape().has_batch() * span * repeat;
     float *dest = DATA(y) + offset;
     const float *src = CDATA(*x);
-    for (unsigned batch = 0; batch < new_bs; ++batch) {
+    for (std::uint32_t batch = 0; batch < new_bs; ++batch) {
       const float *sp = src;
-      for (unsigned i = 0; i < repeat; ++i) {
+      for (std::uint32_t i = 0; i < repeat; ++i) {
         float *dp = dest;
         REPEAT_OP(j, span, *dp++ = *sp++);
         dest += skip;
@@ -214,18 +214,18 @@ void Naive::concat_fw_impl(
 }
 
 void Naive::pick_bw_impl(
-    const Tensor &gy, const std::vector<unsigned>& ids, unsigned dim,
+    const Tensor &gy, const std::vector<std::uint32_t>& ids, std::uint32_t dim,
     Tensor &gx) {
-  const unsigned bs = gy.shape().batch();
-  const unsigned skip_x = gx.shape().has_batch() * gx.shape().volume();
-  const unsigned skip_i = ids.size() > 1;
-  const unsigned base = gy.shape().lower_volume(dim);
-  const unsigned skip = base * gx.shape()[dim];
-  const unsigned repeat = gy.shape().volume() / base;
+  const std::uint32_t bs = gy.shape().batch();
+  const std::uint32_t skip_x = gx.shape().has_batch() * gx.shape().volume();
+  const std::uint32_t skip_i = ids.size() > 1;
+  const std::uint32_t base = gy.shape().lower_volume(dim);
+  const std::uint32_t skip = base * gx.shape()[dim];
+  const std::uint32_t repeat = gy.shape().volume() / base;
   const float *src = CDATA(gy);
-  for (unsigned batch = 0; batch < bs; ++batch) {
+  for (std::uint32_t batch = 0; batch < bs; ++batch) {
     float *dest = DATA(gx) + batch * skip_x + base * ids[batch * skip_i];
-    for (unsigned i = 0; i < repeat; ++i) {
+    for (std::uint32_t i = 0; i < repeat; ++i) {
       float *dp = dest;
       REPEAT_OP(j, base, *dp++ += *src++);
       dest += skip;
@@ -234,22 +234,22 @@ void Naive::pick_bw_impl(
 }
 
 void Naive::slice_bw_impl(
-    const Tensor &gy, unsigned dim, unsigned offset, Tensor &gx) {
+    const Tensor &gy, std::uint32_t dim, std::uint32_t offset, Tensor &gx) {
   const Shape &sy = gy.shape();
   const Shape &sx = gx.shape();
-  const unsigned base = sx.lower_volume(dim);
-  const unsigned span = base * sy[dim];
-  const unsigned skip = base * sx[dim];
-  const unsigned repeat = sx.volume() / skip;
-  const unsigned bs = std::max(sx.batch(), sy.batch());
-  const unsigned b_skip_d = sx.has_batch() * sx.volume();
-  const unsigned b_skip_s = sy.has_batch() * sy.volume();
+  const std::uint32_t base = sx.lower_volume(dim);
+  const std::uint32_t span = base * sy[dim];
+  const std::uint32_t skip = base * sx[dim];
+  const std::uint32_t repeat = sx.volume() / skip;
+  const std::uint32_t bs = std::max(sx.batch(), sy.batch());
+  const std::uint32_t b_skip_d = sx.has_batch() * sx.volume();
+  const std::uint32_t b_skip_s = sy.has_batch() * sy.volume();
   float *dest = DATA(gx) + base * offset;
   const float *src = CDATA(gy);
-  for (unsigned batch = 0; batch < bs; ++batch) {
+  for (std::uint32_t batch = 0; batch < bs; ++batch) {
     float *dp = dest;
     const float *sp = src;
-    for (unsigned i = 0; i < repeat; ++i) {
+    for (std::uint32_t i = 0; i < repeat; ++i) {
       float *ddp = dp;
       REPEAT_OP(j, span, *ddp++ += *sp++);
       dp += skip;
@@ -263,7 +263,7 @@ void Naive::slice_bw_impl(
 void Naive::name##_fw_impl(const Tensor &x, Tensor &y) { \
   float *dest = DATA(y); \
   const float *src = CDATA(x); \
-  const unsigned size = x.shape().size(); \
+  const std::uint32_t size = x.shape().size(); \
   REPEAT_OP(i, size, dest[i] = (op)); \
 }
 
@@ -274,7 +274,7 @@ void Naive::name##_bw_impl( \
   const float *py = CDATA(y); static_cast<void>(py); \
   const float *pgy = CDATA(gy); \
   float *pgx = DATA(gx); \
-  const unsigned size = x.shape().size(); \
+  const std::uint32_t size = x.shape().size(); \
   REPEAT_OP(i, size, pgx[i] += (op)); \
 }
 
@@ -282,7 +282,7 @@ void Naive::name##_bw_impl( \
 void Naive::name##_fw_impl(const Tensor &x, float k, Tensor &y) { \
   float *dest = DATA(y); \
   const float *src = CDATA(x); \
-  const unsigned size = x.shape().size(); \
+  const std::uint32_t size = x.shape().size(); \
   REPEAT_OP(i, size, dest[i] = (op)); \
 }
 
@@ -293,20 +293,20 @@ void Naive::name##_bw_impl( \
   const float *py = CDATA(y); static_cast<void>(py); \
   const float *pgy = CDATA(gy); \
   float *pgx = DATA(gx); \
-  const unsigned size = x.shape().size(); \
+  const std::uint32_t size = x.shape().size(); \
   REPEAT_OP(i, size, pgx[i] += (op)); \
 }
 
 #define CPUDEV_FW_X_SCALAR(name, op) \
 void Naive::name##_fw_impl(const Tensor &x, const Tensor &k, Tensor &y) { \
-  const unsigned size = y.shape().volume(); \
-  const unsigned bs = y.shape().batch(); \
-  const unsigned skip_x = x.shape().has_batch() * size; \
-  const unsigned skip_k = k.shape().has_batch(); \
+  const std::uint32_t size = y.shape().volume(); \
+  const std::uint32_t bs = y.shape().batch(); \
+  const std::uint32_t skip_x = x.shape().has_batch() * size; \
+  const std::uint32_t skip_k = k.shape().has_batch(); \
   float *dest = DATA(y); \
   const float *src_x = CDATA(x); \
   const float *src_k = CDATA(k); \
-  for (unsigned batch = 0; batch < bs; ++batch) { \
+  for (std::uint32_t batch = 0; batch < bs; ++batch) { \
     REPEAT_OP(i, size, dest[i] = (op)); \
     dest += size; \
     src_x += skip_x; \
@@ -316,14 +316,14 @@ void Naive::name##_fw_impl(const Tensor &x, const Tensor &k, Tensor &y) { \
 
 #define CPUDEV_FW_AB(name, op) \
 void Naive::name##_fw_impl(const Tensor &a, const Tensor &b, Tensor &y) { \
-  const unsigned size = y.shape().volume(); \
-  const unsigned bs = y.shape().batch(); \
-  const unsigned skip_a = a.shape().has_batch() * size; \
-  const unsigned skip_b = b.shape().has_batch() * size; \
+  const std::uint32_t size = y.shape().volume(); \
+  const std::uint32_t bs = y.shape().batch(); \
+  const std::uint32_t skip_a = a.shape().has_batch() * size; \
+  const std::uint32_t skip_b = b.shape().has_batch() * size; \
   float *dest = DATA(y); \
   const float *src_a = CDATA(a); \
   const float *src_b = CDATA(b); \
-  for (unsigned batch = 0; batch < bs; ++batch) { \
+  for (std::uint32_t batch = 0; batch < bs; ++batch) { \
     REPEAT_OP(i, size, dest[i] = (op)); \
     dest += size; \
     src_a += skip_a; \
@@ -396,15 +396,15 @@ CPUDEV_FW_AB(divide, src_a[i] / src_b[i]);
 void Naive::add_bw_impl(
     const Tensor &, const Tensor &, const Tensor &, const Tensor &gy,
     Tensor &ga, Tensor &gb) {
-  const unsigned size = gy.shape().volume();
-  const unsigned bs = gy.shape().batch();
-  const unsigned skip_a = ga.shape().has_batch() * size;
-  const unsigned skip_b = gb.shape().has_batch() * size;
+  const std::uint32_t size = gy.shape().volume();
+  const std::uint32_t bs = gy.shape().batch();
+  const std::uint32_t skip_a = ga.shape().has_batch() * size;
+  const std::uint32_t skip_b = gb.shape().has_batch() * size;
   const float *pgy = CDATA(gy);
   float *pga = DATA(ga);
   float *pgb = DATA(gb);
-  for (unsigned batch = 0; batch < bs; ++batch) {
-    for (unsigned i = 0; i < size; ++i) {
+  for (std::uint32_t batch = 0; batch < bs; ++batch) {
+    for (std::uint32_t i = 0; i < size; ++i) {
       const float k = pgy[i];
       pga[i] += k;
       pgb[i] += k;
@@ -418,15 +418,15 @@ void Naive::add_bw_impl(
 void Naive::subtract_bw_impl(
     const Tensor &, const Tensor &, const Tensor &, const Tensor &gy,
     Tensor &ga, Tensor &gb) {
-  const unsigned size = gy.shape().volume();
-  const unsigned bs = gy.shape().batch();
-  const unsigned skip_a = ga.shape().has_batch() * size;
-  const unsigned skip_b = gb.shape().has_batch() * size;
+  const std::uint32_t size = gy.shape().volume();
+  const std::uint32_t bs = gy.shape().batch();
+  const std::uint32_t skip_a = ga.shape().has_batch() * size;
+  const std::uint32_t skip_b = gb.shape().has_batch() * size;
   const float *pgy = CDATA(gy);
   float *pga = DATA(ga);
   float *pgb = DATA(gb);
-  for (unsigned batch = 0; batch < bs; ++batch) {
-    for (unsigned i = 0; i < size; ++i) {
+  for (std::uint32_t batch = 0; batch < bs; ++batch) {
+    for (std::uint32_t i = 0; i < size; ++i) {
       const float k = pgy[i];
       pga[i] += k;
       pgb[i] -= k;
@@ -440,17 +440,17 @@ void Naive::subtract_bw_impl(
 void Naive::multiply_bw_impl(
     const Tensor &a, const Tensor &b, const Tensor &, const Tensor &gy,
     Tensor &ga, Tensor &gb) {
-  const unsigned size = gy.shape().volume();
-  const unsigned bs = gy.shape().batch();
-  const unsigned skip_a = ga.shape().has_batch() * size;
-  const unsigned skip_b = gb.shape().has_batch() * size;
+  const std::uint32_t size = gy.shape().volume();
+  const std::uint32_t bs = gy.shape().batch();
+  const std::uint32_t skip_a = ga.shape().has_batch() * size;
+  const std::uint32_t skip_b = gb.shape().has_batch() * size;
   const float *pa = CDATA(a);
   const float *pb = CDATA(b);
   const float *pgy = CDATA(gy);
   float *pga = DATA(ga);
   float *pgb = DATA(gb);
-  for (unsigned batch = 0; batch < bs; ++batch) {
-    for (unsigned i = 0; i < size; ++i) {
+  for (std::uint32_t batch = 0; batch < bs; ++batch) {
+    for (std::uint32_t i = 0; i < size; ++i) {
       const float k = pgy[i];
       pga[i] += k * pb[i];
       pgb[i] += k * pa[i];
@@ -466,17 +466,17 @@ void Naive::multiply_bw_impl(
 void Naive::divide_bw_impl(
     const Tensor &, const Tensor &b, const Tensor &y, const Tensor &gy,
     Tensor &ga, Tensor &gb) {
-  const unsigned size = gy.shape().volume();
-  const unsigned bs = gy.shape().batch();
-  const unsigned skip_a = ga.shape().has_batch() * size;
-  const unsigned skip_b = gb.shape().has_batch() * size;
+  const std::uint32_t size = gy.shape().volume();
+  const std::uint32_t bs = gy.shape().batch();
+  const std::uint32_t skip_a = ga.shape().has_batch() * size;
+  const std::uint32_t skip_b = gb.shape().has_batch() * size;
   const float *pb = CDATA(b);
   const float *py = CDATA(y);
   const float *pgy = CDATA(gy);
   float *pga = DATA(ga);
   float *pgb = DATA(gb);
-  for (unsigned batch = 0; batch < bs; ++batch) {
-    for (unsigned i = 0; i < size; ++i) {
+  for (std::uint32_t batch = 0; batch < bs; ++batch) {
+    for (std::uint32_t i = 0; i < size; ++i) {
       const float k = pgy[i] / pb[i];
       pga[i] += k;
       pgb[i] -= k * py[i];
@@ -490,18 +490,18 @@ void Naive::divide_bw_impl(
 }
 
 void Naive::transpose_fw_impl(const Tensor &x, Tensor &y) {
-  const unsigned d1 = x.shape()[0];
-  const unsigned d2 = x.shape()[1];
-  const unsigned ms = d1 * d2;
-  const unsigned bs = y.shape().batch();
+  const std::uint32_t d1 = x.shape()[0];
+  const std::uint32_t d2 = x.shape()[1];
+  const std::uint32_t ms = d1 * d2;
+  const std::uint32_t bs = y.shape().batch();
   float *dest = DATA(y);
   const float *src = CDATA(x);
 
-  for (unsigned k = 0; k < bs; ++k) {
+  for (std::uint32_t k = 0; k < bs; ++k) {
     float *pd = dest;
-    for (unsigned j = 0; j < d2; ++j) {
+    for (std::uint32_t j = 0; j < d2; ++j) {
       float *ppd = pd;
-      for (unsigned i = 0; i < d1; ++i) {
+      for (std::uint32_t i = 0; i < d1; ++i) {
         *ppd = *src++;
         ppd += d2;
       }
@@ -512,22 +512,22 @@ void Naive::transpose_fw_impl(const Tensor &x, Tensor &y) {
 }
 
 void Naive::matmul_fw_impl(const Tensor &a, const Tensor &b, Tensor &y) {
-  const unsigned d1 = a.shape()[0];
-  const unsigned d2 = a.shape()[1];
-  const unsigned d3 = b.shape()[1];
-  const unsigned bs = y.shape().batch();
-  const unsigned dest_shift = d1 * d3;
-  const unsigned src_a_shift = a.shape().has_batch() * d1 * d2;
-  const unsigned src_b_shift = b.shape().has_batch() * d2 * d3;
+  const std::uint32_t d1 = a.shape()[0];
+  const std::uint32_t d2 = a.shape()[1];
+  const std::uint32_t d3 = b.shape()[1];
+  const std::uint32_t bs = y.shape().batch();
+  const std::uint32_t dest_shift = d1 * d3;
+  const std::uint32_t src_a_shift = a.shape().has_batch() * d1 * d2;
+  const std::uint32_t src_b_shift = b.shape().has_batch() * d2 * d3;
 
   float *dest = DATA(y);
   const float *src_a = CDATA(a);
   const float *src_b = CDATA(b);
-  for (unsigned batch = 0; batch < bs; ++batch) {
-    for (unsigned i = 0; i < d1; ++i) {
-      for (unsigned ky = 0, kb = 0; ky < dest_shift; ky += d1, kb += d2) {
+  for (std::uint32_t batch = 0; batch < bs; ++batch) {
+    for (std::uint32_t i = 0; i < d1; ++i) {
+      for (std::uint32_t ky = 0, kb = 0; ky < dest_shift; ky += d1, kb += d2) {
         float tmp = 0;
-        for (unsigned ja = 0, jb = 0; jb < d2; ja += d1, ++jb) {
+        for (std::uint32_t ja = 0, jb = 0; jb < d2; ja += d1, ++jb) {
           tmp += src_a[i + ja] * src_b[jb + kb];
         }
         dest[i + ky] = tmp;
@@ -553,17 +553,17 @@ void Naive::matmul_bw_impl(
   inplace_add_impl(matmul_fw(transpose_fw(a), gy), gb);
 }
 
-void Naive::sum_fw_impl(const Tensor &x, unsigned dim, Tensor &y) {
-  const unsigned n = x.shape()[dim];
-  const unsigned repeat = y.shape().size();
-  const unsigned skip1 = y.shape().lower_volume(dim);
-  const unsigned skip2 = skip1 * n;
+void Naive::sum_fw_impl(const Tensor &x, std::uint32_t dim, Tensor &y) {
+  const std::uint32_t n = x.shape()[dim];
+  const std::uint32_t repeat = y.shape().size();
+  const std::uint32_t skip1 = y.shape().lower_volume(dim);
+  const std::uint32_t skip2 = skip1 * n;
   float *dest = DATA(y);
   const float *src = CDATA(x);
-  for (unsigned i = 0; i < repeat; ++i) {
-    unsigned offset = i % skip1 + (i / skip1) * skip2;
+  for (std::uint32_t i = 0; i < repeat; ++i) {
+    std::uint32_t offset = i % skip1 + (i / skip1) * skip2;
     float tmp = 0;
-    for (unsigned j = 0; j < n; ++j) {
+    for (std::uint32_t j = 0; j < n; ++j) {
       tmp += src[offset];
       offset += skip1;
     }
@@ -571,18 +571,18 @@ void Naive::sum_fw_impl(const Tensor &x, unsigned dim, Tensor &y) {
   }
 }
 
-void Naive::logsumexp_fw_impl(const Tensor &x, unsigned dim, Tensor &y) {
-  const unsigned n = x.shape()[dim];
-  const unsigned repeat = y.shape().size();
-  const unsigned skip1 = y.shape().lower_volume(dim);
-  const unsigned skip2 = skip1 * n;
+void Naive::logsumexp_fw_impl(const Tensor &x, std::uint32_t dim, Tensor &y) {
+  const std::uint32_t n = x.shape()[dim];
+  const std::uint32_t repeat = y.shape().size();
+  const std::uint32_t skip1 = y.shape().lower_volume(dim);
+  const std::uint32_t skip2 = skip1 * n;
   float *dest = DATA(y);
   const float *src = CDATA(x);
-  for (unsigned i = 0; i < repeat; ++i) {
+  for (std::uint32_t i = 0; i < repeat; ++i) {
     // TODO(odashi): This calculation might generate large errors.
-    unsigned offset = i % skip1 + (i / skip1) * skip2;
+    std::uint32_t offset = i % skip1 + (i / skip1) * skip2;
     float tmp = src[offset];
-    for (unsigned j = 1; j < n; ++j) {
+    for (std::uint32_t j = 1; j < n; ++j) {
       offset += skip1;
       float arg = src[offset];
       tmp = tmp > arg
@@ -594,16 +594,16 @@ void Naive::logsumexp_fw_impl(const Tensor &x, unsigned dim, Tensor &y) {
 }
 
 void Naive::broadcast_fw_impl(
-    const Tensor &x, unsigned dim, unsigned size, Tensor &y) {
-  const unsigned repeat = x.shape().size();
-  const unsigned skip1 = y.shape().lower_volume(dim);
-  const unsigned skip2 = skip1 * size;
+    const Tensor &x, std::uint32_t dim, std::uint32_t size, Tensor &y) {
+  const std::uint32_t repeat = x.shape().size();
+  const std::uint32_t skip1 = y.shape().lower_volume(dim);
+  const std::uint32_t skip2 = skip1 * size;
   float *dest = DATA(y);
   const float *src = CDATA(x);
-  for (unsigned i = 0; i < repeat; ++i) {
-    unsigned offset = i % skip1 + (i / skip1) * skip2;
+  for (std::uint32_t i = 0; i < repeat; ++i) {
+    std::uint32_t offset = i % skip1 + (i / skip1) * skip2;
     float tmp = src[i];
-    for (unsigned j = 0; j < size; ++j) {
+    for (std::uint32_t j = 0; j < size; ++j) {
       dest[offset] = tmp;
       offset += skip1;
     }
@@ -613,11 +613,11 @@ void Naive::broadcast_fw_impl(
 void Naive::batch_sum_fw_impl(const Tensor &x, Tensor &y) {
   float *dest = DATA(y);
   const float *src = CDATA(x);
-  const unsigned bs = x.shape().batch();
-  const unsigned size = y.shape().size();
-  for (unsigned i = 0; i < size; ++i) {
+  const std::uint32_t bs = x.shape().batch();
+  const std::uint32_t size = y.shape().size();
+  for (std::uint32_t i = 0; i < size; ++i) {
     float temp = 0;
-    for (unsigned batch = 0, pos = i; batch < bs; ++batch, pos += size) {
+    for (std::uint32_t batch = 0, pos = i; batch < bs; ++batch, pos += size) {
       temp += src[pos];
     }
     dest[i] = temp;
@@ -625,7 +625,7 @@ void Naive::batch_sum_fw_impl(const Tensor &x, Tensor &y) {
 }
 
 void Naive::inplace_multiply_const_impl(float k, Tensor &x) {
-  const unsigned size = x.shape().size();
+  const std::uint32_t size = x.shape().size();
   float *dest = DATA(x);
   REPEAT_OP(i, size, dest[i] *= k);
 }
@@ -633,13 +633,13 @@ void Naive::inplace_multiply_const_impl(float k, Tensor &x) {
 void Naive::inplace_add_impl(const Tensor &x, Tensor &y) {
   const Shape &sx = x.shape();
   const Shape &sy = y.shape();
-  const unsigned size = sy.volume();
-  const unsigned bs = std::max(sx.batch(), sy.batch());
-  const unsigned b_skip_d = sy.has_batch() * size;
-  const unsigned b_skip_s = sx.has_batch() * size;
+  const std::uint32_t size = sy.volume();
+  const std::uint32_t bs = std::max(sx.batch(), sy.batch());
+  const std::uint32_t b_skip_d = sy.has_batch() * size;
+  const std::uint32_t b_skip_s = sx.has_batch() * size;
   float *dest = DATA(y);
   const float *src = CDATA(x);
-  for (unsigned batch = 0; batch < bs; ++batch) {
+  for (std::uint32_t batch = 0; batch < bs; ++batch) {
     REPEAT_OP(i, size, dest[i] += src[i]);
     dest += b_skip_d;
     src += b_skip_s;
@@ -649,13 +649,13 @@ void Naive::inplace_add_impl(const Tensor &x, Tensor &y) {
 void Naive::inplace_subtract_impl(const Tensor &x, Tensor &y) {
   const Shape &sx = x.shape();
   const Shape &sy = y.shape();
-  const unsigned size = sy.volume();
-  const unsigned bs = std::max(sx.batch(), sy.batch());
-  const unsigned b_skip_d = sy.has_batch() * size;
-  const unsigned b_skip_s = sx.has_batch() * size;
+  const std::uint32_t size = sy.volume();
+  const std::uint32_t bs = std::max(sx.batch(), sy.batch());
+  const std::uint32_t b_skip_d = sy.has_batch() * size;
+  const std::uint32_t b_skip_s = sx.has_batch() * size;
   float *dest = DATA(y);
   const float *src = CDATA(x);
-  for (unsigned batch = 0; batch < bs; ++batch) {
+  for (std::uint32_t batch = 0; batch < bs; ++batch) {
     REPEAT_OP(i, size, dest[i] -= src[i]);
     dest += b_skip_d;
     src += b_skip_s;

--- a/primitiv/naive_device.h
+++ b/primitiv/naive_device.h
@@ -23,7 +23,7 @@ public:
    * Creates a Naive object.
    * @param rng_seed The seed value of internal random number generator.
    */
-  explicit Naive(unsigned rng_seed) : rng_(rng_seed) {}
+  explicit Naive(std::uint32_t rng_seed) : rng_(rng_seed) {}
 
   ~Naive() override = default;
 
@@ -34,8 +34,8 @@ private:
   std::shared_ptr<void> new_handle(const Shape &shape) override;
 
   std::vector<float> tensor_to_vector_impl(const Tensor &x) override;
-  std::vector<unsigned> argmax_impl(const Tensor &x, unsigned dim) override;
-  std::vector<unsigned> argmin_impl(const Tensor &x, unsigned dim) override;
+  std::vector<std::uint32_t> argmax_impl(const Tensor &x, std::uint32_t dim) override;
+  std::vector<std::uint32_t> argmin_impl(const Tensor &x, std::uint32_t dim) override;
 
   void reset_tensor_impl(float k, Tensor &x) override;
   void reset_tensor_by_array_impl(const float values[], Tensor &x) override;
@@ -49,12 +49,12 @@ private:
   void random_normal_impl(float mean, float sd, Tensor &y) override;
   void random_log_normal_impl(float mean, float sd, Tensor &y) override;
 
-  void pick_fw_impl(const Tensor &x, const std::vector<unsigned> &ids, unsigned dim, Tensor &y) override;
-  void slice_fw_impl(const Tensor &x, unsigned dim, unsigned offset, Tensor &y) override;
-  void concat_fw_impl(const std::vector<const Tensor *> &xs, unsigned dim, Tensor &y) override;
+  void pick_fw_impl(const Tensor &x, const std::vector<std::uint32_t> &ids, std::uint32_t dim, Tensor &y) override;
+  void slice_fw_impl(const Tensor &x, std::uint32_t dim, std::uint32_t offset, Tensor &y) override;
+  void concat_fw_impl(const std::vector<const Tensor *> &xs, std::uint32_t dim, Tensor &y) override;
 
-  void pick_bw_impl(const Tensor &gy, const std::vector<unsigned> &ids, unsigned dim, Tensor &gx) override;
-  void slice_bw_impl(const Tensor &gy, unsigned dim, unsigned offset, Tensor &gx) override;
+  void pick_bw_impl(const Tensor &gy, const std::vector<std::uint32_t> &ids, std::uint32_t dim, Tensor &gx) override;
+  void slice_bw_impl(const Tensor &gy, std::uint32_t dim, std::uint32_t offset, Tensor &gx) override;
 
   void negate_fw_impl(const Tensor &x, Tensor &y) override;
   void sqrt_fw_impl(const Tensor &x, Tensor &y) override;
@@ -126,9 +126,9 @@ private:
       const Tensor &a, const Tensor &b, const Tensor &y, const Tensor &gy,
       Tensor &ga, Tensor &gb) override;
 
-  void sum_fw_impl(const Tensor &x, unsigned dim, Tensor &y) override;
-  void logsumexp_fw_impl(const Tensor &x, unsigned dim, Tensor &y) override;
-  void broadcast_fw_impl(const Tensor &x, unsigned dim, unsigned size, Tensor &y) override;
+  void sum_fw_impl(const Tensor &x, std::uint32_t dim, Tensor &y) override;
+  void logsumexp_fw_impl(const Tensor &x, std::uint32_t dim, Tensor &y) override;
+  void broadcast_fw_impl(const Tensor &x, std::uint32_t dim, std::uint32_t size, Tensor &y) override;
   void batch_sum_fw_impl(const Tensor &x, Tensor &y) override;
 
   void inplace_multiply_const_impl(float k, Tensor &x) override;

--- a/primitiv/node_ops.cc
+++ b/primitiv/node_ops.cc
@@ -120,24 +120,24 @@ Node copy(const Node &x, Device &dev) {
 }
 
 template<>
-Node pick(const Node &x, const std::vector<unsigned> &ids, unsigned dim) {
+Node pick(const Node &x, const std::vector<std::uint32_t> &ids, std::uint32_t dim) {
   return REGX(x, Pick(ids, dim), x);
 }
 
 template<>
-Node slice(const Node &x, unsigned dim, unsigned lower, unsigned upper) {
+Node slice(const Node &x, std::uint32_t dim, std::uint32_t lower, std::uint32_t upper) {
   return REGX(x, Slice(dim, lower, upper), x);
 }
 
 template<>
-Node concat(const std::vector<Node> &xs, unsigned dim) {
+Node concat(const std::vector<Node> &xs, std::uint32_t dim) {
   if (xs.empty()) THROW_ERROR("No nodes to concat.");
   return xs[0].graph().add_function(
       std::unique_ptr<Function>(new F::Concat(dim)), xs);
 }
 
 template<>
-Node concat(const std::vector<const Node *> &xs, unsigned dim) {
+Node concat(const std::vector<const Node *> &xs, std::uint32_t dim) {
   return concat(::ptr_to_obj(xs), dim);
 }
 
@@ -227,37 +227,37 @@ Node elu(const Node &x, float a) {
 }
 
 template<>
-Node sum(const Node &x, unsigned dim) {
+Node sum(const Node &x, std::uint32_t dim) {
   return REGX(x, Sum(dim), x);
 }
 
 template<>
-Node broadcast(const Node &x, unsigned dim, unsigned size) {
+Node broadcast(const Node &x, std::uint32_t dim, std::uint32_t size) {
   return REGX(x, Broadcast(dim, size), x);
 }
 
 template<>
-Node logsumexp(const Node &x, unsigned dim) {
+Node logsumexp(const Node &x, std::uint32_t dim) {
   return REGX(x, LogSumExp(dim), x);
 }
 
 template<>
-Node log_softmax(const Node &x, unsigned dim) {
+Node log_softmax(const Node &x, std::uint32_t dim) {
   return x - broadcast(logsumexp(x, dim), dim, x.shape()[dim]);
 }
 
 template<>
-Node softmax(const Node &x, unsigned dim) {
+Node softmax(const Node &x, std::uint32_t dim) {
   return exp(log_softmax(x, dim));
 }
 
 template<>
-Node softmax_cross_entropy(const Node &x, const Node &t, unsigned dim) {
+Node softmax_cross_entropy(const Node &x, const Node &t, std::uint32_t dim) {
   return REGX(x, SoftmaxCrossEntropy(dim), x, t);
 }
 
 template<>
-Node softmax_cross_entropy(const Node &x, const std::vector<unsigned> &ids, unsigned dim) {
+Node softmax_cross_entropy(const Node &x, const std::vector<std::uint32_t> &ids, std::uint32_t dim) {
   return REGX(x, SparseSoftmaxCrossEntropy(ids, dim), x);
 }
 
@@ -274,7 +274,7 @@ Node constant(const Shape &shape, float k, Device &dev, Graph &g) {
   return REG(g, Constant(shape, k, dev));
 }
 
-Node identity(unsigned size, Device &dev, Graph &g) {
+Node identity(std::uint32_t size, Device &dev, Graph &g) {
   return REG(g, IdentityMatrix(size, dev));
 }
 
@@ -284,7 +284,7 @@ Node constant<Node>(const Shape &shape, float k, Device &dev) {
 }
 
 template<>
-Node identity<Node>(unsigned size, Device &dev) {
+Node identity<Node>(std::uint32_t size, Device &dev) {
   return identity(size, dev, Graph::get_default());
 }
 

--- a/primitiv/parameter.cc
+++ b/primitiv/parameter.cc
@@ -17,9 +17,9 @@ void store_shape(const primitiv::Shape &src, primitiv::messages::Shape &dest) {
   dest.Clear();
 
   auto &dims = *dest.mutable_dims();
-  const unsigned dims_size = src.depth();
+  const std::uint32_t dims_size = src.depth();
   dims.Reserve(dims_size);
-  for (unsigned i = 0; i < dims_size; ++i) {
+  for (std::uint32_t i = 0; i < dims_size; ++i) {
     dims.AddAlreadyReserved(src[i]);
   }
   dest.set_batch(src.batch());
@@ -34,9 +34,9 @@ void store_tensor(const primitiv::Tensor &src, primitiv::messages::Tensor &dest)
   ::store_shape(src.shape(), *dest.mutable_shape());
   auto &data = *dest.mutable_data();
   const vector<float> src_data = src.to_vector();
-  const unsigned data_size = src_data.size();
+  const std::uint32_t data_size = src_data.size();
   data.Reserve(data_size);
-  for (unsigned i = 0; i < data_size; ++i) {
+  for (std::uint32_t i = 0; i < data_size; ++i) {
     data.AddAlreadyReserved(src_data[i]);
   }
 }
@@ -44,7 +44,7 @@ void store_tensor(const primitiv::Tensor &src, primitiv::messages::Tensor &dest)
 // Parses Shape data in the proto message.
 primitiv::Shape parse_shape(const primitiv::messages::Shape &src) {
   return primitiv::Shape(
-      vector<unsigned>(src.dims().begin(), src.dims().end()),
+      vector<std::uint32_t>(src.dims().begin(), src.dims().end()),
       src.batch());
 }
 
@@ -55,7 +55,7 @@ primitiv::Tensor parse_tensor(const primitiv::messages::Tensor &src, primitiv::D
   }
 
   primitiv::Shape shape = ::parse_shape(src.shape());
-  if (static_cast<unsigned>(src.data_size()) != shape.size()) {
+  if (static_cast<std::uint32_t>(src.data_size()) != shape.size()) {
     THROW_ERROR(
         "Invalid Tensor message: data sizes mismatched."
         << " src.data_size(): " << std::to_string(src.data_size())

--- a/primitiv/shape.cc
+++ b/primitiv/shape.cc
@@ -5,14 +5,14 @@
 
 namespace primitiv {
 
-Shape::Shape(std::initializer_list<unsigned> dims, unsigned batch)
+Shape::Shape(std::initializer_list<std::uint32_t> dims, std::uint32_t batch)
 : depth_(0), batch_(batch), volume_(1) {
   if (dims.size() > MAX_DEPTH) {
     THROW_ERROR(
         "Exceeds dimension depth limit at Shape::Shape()."
         " depth: " << depth_ << " > MAX_DEPTH: " << MAX_DEPTH);
   }
-  for (const unsigned d : dims) {
+  for (const std::uint32_t d : dims) {
     dims_[depth_++] = d;
     volume_ *= d;
   }
@@ -22,14 +22,14 @@ Shape::Shape(std::initializer_list<unsigned> dims, unsigned batch)
   }
 }
 
-Shape::Shape(const std::vector<unsigned> &dims, unsigned batch)
+Shape::Shape(const std::vector<std::uint32_t> &dims, std::uint32_t batch)
 : depth_(0), batch_(batch), volume_(1) {
   if (dims.size() > MAX_DEPTH) {
     THROW_ERROR(
         "Exceeds dimension depth limit at Shape::Shape()."
         " depth: " << depth_ << " > MAX_DEPTH: " << MAX_DEPTH);
   }
-  for (const unsigned d : dims) {
+  for (const std::uint32_t d : dims) {
     dims_[depth_++] = d;
     volume_ *= d;
   }
@@ -52,7 +52,7 @@ Shape &Shape::operator=(Shape &&src) {
 std::string Shape::to_string() const {
   std::stringstream s;
   s << '[';
-  for (unsigned i = 0; i < depth_; ++i) {
+  for (std::uint32_t i = 0; i < depth_; ++i) {
     if (i > 0) {
       s << ',';
     }
@@ -62,31 +62,31 @@ std::string Shape::to_string() const {
   return s.str();
 }
 
-bool Shape::has_same_loo_dims(const Shape &rhs, unsigned dim) const {
-  unsigned nl = depth_ == dim + 1 ? dim : depth_;
+bool Shape::has_same_loo_dims(const Shape &rhs, std::uint32_t dim) const {
+  std::uint32_t nl = depth_ == dim + 1 ? dim : depth_;
   while (nl > 0 && dims_[nl - 1] == 1) --nl;
-  unsigned nr = rhs.depth_ == dim + 1 ? dim : rhs.depth_;
+  std::uint32_t nr = rhs.depth_ == dim + 1 ? dim : rhs.depth_;
   while (nr > 0 && rhs.dims_[nr - 1] == 1) --nr;
   bool p = nl == nr;
-  for (unsigned i = 0; i < nl; ++i) {
+  for (std::uint32_t i = 0; i < nl; ++i) {
     p = p && (dims_[i] == rhs.dims_[i] || i == dim);
   }
   return p;
 }
 
-Shape Shape::resize_dim(unsigned dim, unsigned m) const {
+Shape Shape::resize_dim(std::uint32_t dim, std::uint32_t m) const {
   Shape ret = *this;
   ret.update_dim(dim, m);
   return ret;
 }
 
-Shape Shape::resize_batch(unsigned batch) const {
+Shape Shape::resize_batch(std::uint32_t batch) const {
   Shape ret = *this;
   ret.update_batch(batch);
   return ret;
 }
 
-void Shape::update_dim(unsigned dim, unsigned m) {
+void Shape::update_dim(std::uint32_t dim, std::uint32_t m) {
   if (dim >= MAX_DEPTH) {
     THROW_ERROR(
       "Exceeds dimension depth limit at Shape::update_dim()."
@@ -94,8 +94,8 @@ void Shape::update_dim(unsigned dim, unsigned m) {
   }
   if (m == 0) THROW_ERROR("Could not set each dimension to 0.");
   if (dim >= depth_) {
-    unsigned new_depth = dim + 1;
-    for (unsigned i = depth_; i < new_depth; ++i) dims_[i] = 1;
+    std::uint32_t new_depth = dim + 1;
+    for (std::uint32_t i = depth_; i < new_depth; ++i) dims_[i] = 1;
     depth_ = new_depth;
   }
   volume_ = (volume_ / dims_[dim]) * m;
@@ -103,7 +103,7 @@ void Shape::update_dim(unsigned dim, unsigned m) {
   while (depth_ > 0 && dims_[depth_ - 1] == 1) --depth_;
 }
 
-void Shape::update_batch(unsigned batch) {
+void Shape::update_batch(std::uint32_t batch) {
   if (batch == 0) THROW_ERROR("Could not set the batch size to 0.");
   batch_ = batch;
 }

--- a/primitiv/shape.h
+++ b/primitiv/shape.h
@@ -2,6 +2,7 @@
 #define PRIMITIV_SHAPE_H_
 
 #include <array>
+#include <cstdint>
 #include <initializer_list>
 #include <string>
 #include <vector>
@@ -20,7 +21,7 @@ namespace primitiv {
  */
 class Shape {
 public:
-  static const unsigned MAX_DEPTH = 8;
+  static const std::uint32_t MAX_DEPTH = 8;
 
   Shape(const Shape &) = default;
   Shape(Shape &&) = default;
@@ -37,49 +38,49 @@ public:
    * @param dims List of the dimension sizes.
    * @param batch Batch size.
    */
-  Shape(std::initializer_list<unsigned> dims, unsigned batch = 1);
+  Shape(std::initializer_list<std::uint32_t> dims, std::uint32_t batch = 1);
 
   /**
    * Creates a new Shape object.
    * @param dims List of the dimension sizes.
    * @param batch Batch size.
    */
-  Shape(const std::vector<unsigned> &dims, unsigned batch = 1);
+  Shape(const std::vector<std::uint32_t> &dims, std::uint32_t batch = 1);
 
   /**
    * Returns the size of the i-th dimension.
    * @param i Dimension number to check.
    * @return Size of the i-th dimension.
    */
-  unsigned operator[](unsigned i) const { return i < depth_ ? dims_[i] : 1; }
+  std::uint32_t operator[](std::uint32_t i) const { return i < depth_ ? dims_[i] : 1; }
 
   /**
    * Returns the depth (length of non-1 dimensions) of the shape.
    * @return The depth of the shape.
    */
-  unsigned depth() const { return depth_; }
+  std::uint32_t depth() const { return depth_; }
 
   /**
    * Returns the batch size.
    * @return Batch size.
    */
-  unsigned batch() const { return batch_; }
+  std::uint32_t batch() const { return batch_; }
 
   /**
    * Returns the number of elements in each sample.
    * This value is equal to the product of all dimensions.
    * @return Number of elements.
    */
-  unsigned volume() const { return volume_; }
+  std::uint32_t volume() const { return volume_; }
 
   /**
    * Returns the number of elements in 1 to specified dim.
    * @param dim Upper bound of the dimension.
    * @return `dims[0] * dims[1] * ... * dims[dim-1]`
    */
-  unsigned lower_volume(unsigned dim) const {
-    unsigned ret = 1, lim = std::min(dim, depth_);
-    for (unsigned i = 0; i < lim; ++i) ret *= dims_[i];
+  std::uint32_t lower_volume(std::uint32_t dim) const {
+    std::uint32_t ret = 1, lim = std::min(dim, depth_);
+    for (std::uint32_t i = 0; i < lim; ++i) ret *= dims_[i];
     return ret;
   }
 
@@ -88,7 +89,7 @@ public:
    * This value is equal to `batch() * volume()`.
    * @return Number of elements.
    */
-  unsigned size() const { return batch_ * volume_; }
+  std::uint32_t size() const { return batch_ * volume_; }
 
   /**
    * Returns a string representation of the shape.
@@ -153,7 +154,7 @@ public:
    */
   bool has_same_dims(const Shape &rhs) const {
     bool ok = true;
-    for (unsigned i = 0; i < depth_; ++i) ok = ok && dims_[i] == rhs.dims_[i];
+    for (std::uint32_t i = 0; i < depth_; ++i) ok = ok && dims_[i] == rhs.dims_[i];
     return ok && depth_ == rhs.depth_;
   }
 
@@ -165,7 +166,7 @@ public:
    * @return true if both shape have same dimensions regardless the dimension
    *         `dim`, false otherwise.
    */
-  bool has_same_loo_dims(const Shape &rhs, unsigned dim) const;
+  bool has_same_loo_dims(const Shape &rhs, std::uint32_t dim) const;
 
   /**
    * Creates a new shape which have one different dimension.
@@ -173,33 +174,33 @@ public:
    * @param m New size of the dimension `dim`.
    * @return New shape.
    */
-  Shape resize_dim(unsigned dim, unsigned m) const;
+  Shape resize_dim(std::uint32_t dim, std::uint32_t m) const;
 
   /**
    * Creates a new shape which have specified batch size.
    * @param batch New batch size.
    * @return New shape.
    */
-  Shape resize_batch(unsigned batch) const;
+  Shape resize_batch(std::uint32_t batch) const;
 
   /**
    * Directly updates a specified dimension.
    * @param dim Dimension to be updated.
    * @param m New size of the dimension `dim`.
    */
-  void update_dim(unsigned dim, unsigned m);
+  void update_dim(std::uint32_t dim, std::uint32_t m);
 
   /**
    * Directly updates the batch size.
    * @param batch New batch size.
    */
-  void update_batch(unsigned batch);
+  void update_batch(std::uint32_t batch);
 
 private:
-  std::array<unsigned, MAX_DEPTH> dims_;
-  unsigned depth_;
-  unsigned batch_;
-  unsigned volume_;
+  std::array<std::uint32_t, MAX_DEPTH> dims_;
+  std::uint32_t depth_;
+  std::uint32_t batch_;
+  std::uint32_t volume_;
 };
 
 }  // namespace primitiv

--- a/primitiv/shape_ops.cc
+++ b/primitiv/shape_ops.cc
@@ -39,7 +39,7 @@ Shape elementwise(const Shape &a, const Shape &b) {
   return a.resize_batch(std::max(a.batch(), b.batch()));
 }
 
-Shape slice(const Shape &x, unsigned dim, unsigned lower, unsigned upper) {
+Shape slice(const Shape &x, std::uint32_t dim, std::uint32_t lower, std::uint32_t upper) {
   if (lower >= upper || upper > x[dim]) {
     THROW_ERROR(
         "Invalid slice operation. shape: " << x.to_string()
@@ -49,19 +49,19 @@ Shape slice(const Shape &x, unsigned dim, unsigned lower, unsigned upper) {
   return dim >= x.depth() ? x : x.resize_dim(dim, upper - lower);
 }
 
-Shape concat(const std::vector<const Shape *> &xs, unsigned dim) {
+Shape concat(const std::vector<const Shape *> &xs, std::uint32_t dim) {
   if (xs.empty()) {
     THROW_ERROR("No tensors to be concatenated.");
   }
 
   Shape s0 = *xs[0];
-  unsigned sum = s0[dim];
+  std::uint32_t sum = s0[dim];
 
-  for (unsigned i = 1; i < xs.size(); ++i) {
+  for (std::uint32_t i = 1; i < xs.size(); ++i) {
     const Shape &s = *xs[i];
     if (!s0.has_same_loo_dims(s, dim) || !s0.has_compatible_batch(s)) {
       std::string dims_str = xs[0]->to_string();
-      for (unsigned i = 1; i < xs.size(); ++i) {
+      for (std::uint32_t i = 1; i < xs.size(); ++i) {
         dims_str += ", " + xs[i]->to_string();
       }
       THROW_ERROR("Invalid shapes to concatenate: " << dims_str);
@@ -74,7 +74,7 @@ Shape concat(const std::vector<const Shape *> &xs, unsigned dim) {
   return s0;
 }
 
-Shape broadcast(const Shape &x, unsigned dim, unsigned size) {
+Shape broadcast(const Shape &x, std::uint32_t dim, std::uint32_t size) {
   if (x[dim] != 1 || size == 0) {
     THROW_ERROR(
         "Invalid broadcasting. x: "
@@ -83,15 +83,15 @@ Shape broadcast(const Shape &x, unsigned dim, unsigned size) {
   return x.resize_dim(dim, size);
 }
 
-Shape pick(const Shape &x, const std::vector<unsigned> &ids, unsigned dim) {
-  const unsigned n = x[dim];
-  const unsigned bi = ids.size();
+Shape pick(const Shape &x, const std::vector<std::uint32_t> &ids, std::uint32_t dim) {
+  const std::uint32_t n = x[dim];
+  const std::uint32_t bi = ids.size();
   if (bi == 0 || (x.batch() != bi && x.has_batch() && bi > 1)) {
     THROW_ERROR(
         "Invalid IDs to pick. shape: " << x.to_string()
         << ", ids.size(): " << ids.size());
   }
-  for (unsigned i = 0; i < bi; ++i) {
+  for (std::uint32_t i = 0; i < bi; ++i) {
     if (ids[i] >= n) {
       THROW_ERROR(
           "Invalid IDs to pick. shape: " << x.to_string()

--- a/primitiv/shape_ops.h
+++ b/primitiv/shape_ops.h
@@ -1,6 +1,7 @@
 #ifndef PRIMITIV_SHAPE_OPS_H_
 #define PRIMITIV_SHAPE_OPS_H_
 
+#include <cstdint>
 #include <vector>
 #include <primitiv/shape.h>
 
@@ -47,7 +48,7 @@ Shape elementwise(const Shape &a, const Shape &b);
  * @param upper Lower bound of the dimension `dim`.
  * @return A shape.
  */
-Shape slice(const Shape &x, unsigned dim, unsigned lower, unsigned upper);
+Shape slice(const Shape &x, std::uint32_t dim, std::uint32_t lower, std::uint32_t upper);
 
 /**
  * Calculates the concatenated shape.
@@ -55,7 +56,7 @@ Shape slice(const Shape &x, unsigned dim, unsigned lower, unsigned upper);
  * @param dim Dimension to be concatenated.
  * @return A shape.
  */
-Shape concat(const std::vector<const Shape *> &xs, unsigned dim);
+Shape concat(const std::vector<const Shape *> &xs, std::uint32_t dim);
 
 /**
  * Calculates the broadcasted shape.
@@ -64,7 +65,7 @@ Shape concat(const std::vector<const Shape *> &xs, unsigned dim);
  * @param size New size of the dimension `dim`.
  * @return A shape.
  */
-Shape broadcast(const Shape &x, unsigned dim, unsigned size);
+Shape broadcast(const Shape &x, std::uint32_t dim, std::uint32_t size);
 
 /**
  * Calculates the picked shape.
@@ -73,7 +74,7 @@ Shape broadcast(const Shape &x, unsigned dim, unsigned size);
  * @param dim Dimension to pick.
  * @return A shape.
  */
-Shape pick(const Shape &x, const std::vector<unsigned> &ids, unsigned dim);
+Shape pick(const Shape &x, const std::vector<std::uint32_t> &ids, std::uint32_t dim);
 
 /**
  * Calculates the transposed shape.

--- a/primitiv/string_utils.h
+++ b/primitiv/string_utils.h
@@ -1,6 +1,7 @@
 #ifndef PRIMITIV_STRING_UTILS_H_
 #define PRIMITIV_STRING_UTILS_H_
 
+#include <cstdint>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -23,7 +24,7 @@ std::string join(
   if (strs.empty()) return std::string();
   std::stringstream ss;
   ss << strs[0];
-  for (unsigned i = 1; i < strs.size(); ++i) ss << delim << strs[i];
+  for (std::uint32_t i = 1; i < strs.size(); ++i) ss << delim << strs[i];
   return ss.str();
 }
 

--- a/primitiv/tensor.cc
+++ b/primitiv/tensor.cc
@@ -20,12 +20,12 @@ std::vector<float> Tensor::to_vector() const {
   return device_->tensor_to_vector(*this);
 }
 
-std::vector<unsigned> Tensor::argmax(unsigned dim) const {
+std::vector<std::uint32_t> Tensor::argmax(std::uint32_t dim) const {
   if (!valid()) THROW_ERROR("Invalid tensor.");
   return device_->argmax(*this, dim);
 }
 
-std::vector<unsigned> Tensor::argmin(unsigned dim) const {
+std::vector<std::uint32_t> Tensor::argmin(std::uint32_t dim) const {
   if (!valid()) THROW_ERROR("Invalid tensor.");
   return device_->argmin(*this, dim);
 }

--- a/primitiv/tensor.h
+++ b/primitiv/tensor.h
@@ -1,6 +1,7 @@
 #ifndef PRIMITIV_TENSOR_H_
 #define PRIMITIV_TENSOR_H_
 
+#include <cstdint>
 #include <memory>
 #include <vector>
 #include <primitiv/error.h>
@@ -105,14 +106,14 @@ public:
    * @param dim A specified axis.
    * @return A list of integers that indicates positions of the maximum values.
    */
-  std::vector<unsigned> argmax(unsigned dim) const;
+  std::vector<std::uint32_t> argmax(std::uint32_t dim) const;
 
   /**
    * Retrieves argmin indices along an axis.
    * @param dim A specified axis.
    * @return A list of integers that indicates positions of the minimum values.
    */
-  std::vector<unsigned> argmin(unsigned dim) const;
+  std::vector<std::uint32_t> argmin(std::uint32_t dim) const;
 
   /**
    * Reset internal values using a constant.

--- a/primitiv/tensor_ops.cc
+++ b/primitiv/tensor_ops.cc
@@ -117,23 +117,23 @@ Tensor copy(const Tensor &x, Device &dev) {
 }
 
 template<>
-Tensor pick(const Tensor &x, const std::vector<unsigned> &ids, unsigned dim) {
+Tensor pick(const Tensor &x, const std::vector<std::uint32_t> &ids, std::uint32_t dim) {
   return x.device().pick_fw(x, ids, dim);
 }
 
 template<>
-Tensor slice(const Tensor &x, unsigned dim, unsigned lower, unsigned upper) {
+Tensor slice(const Tensor &x, std::uint32_t dim, std::uint32_t lower, std::uint32_t upper) {
   return x.device().slice_fw(x, dim, lower, upper);
 }
 
 template<>
-Tensor concat(const std::vector<const Tensor *> &xs, unsigned dim) {
+Tensor concat(const std::vector<const Tensor *> &xs, std::uint32_t dim) {
   if (xs.empty()) THROW_ERROR("No tensors to be concatenated.");
   return xs[0]->device().concat_fw(xs, dim);
 }
 
 template<>
-Tensor concat(const std::vector<Tensor> &xs, unsigned dim) {
+Tensor concat(const std::vector<Tensor> &xs, std::uint32_t dim) {
   return concat(::obj_to_ptr(xs), dim);
 }
 
@@ -223,38 +223,38 @@ Tensor elu(const Tensor &x, float a) {
 }
 
 template<>
-Tensor sum(const Tensor &x, unsigned dim) {
+Tensor sum(const Tensor &x, std::uint32_t dim) {
   return x.device().sum_fw(x, dim);
 }
 
 template<>
-Tensor broadcast(const Tensor &x, unsigned dim, unsigned size) {
+Tensor broadcast(const Tensor &x, std::uint32_t dim, std::uint32_t size) {
   return x.device().broadcast_fw(x, dim, size);
 }
 
 template<>
-Tensor logsumexp(const Tensor &x, unsigned dim) {
+Tensor logsumexp(const Tensor &x, std::uint32_t dim) {
   return x.device().logsumexp_fw(x, dim);
 }
 
 template<>
-Tensor log_softmax(const Tensor &x, unsigned dim) {
+Tensor log_softmax(const Tensor &x, std::uint32_t dim) {
   return x - broadcast(logsumexp(x, dim), dim, x.shape()[dim]);
 }
 
 template<>
-Tensor softmax(const Tensor &x, unsigned dim) {
+Tensor softmax(const Tensor &x, std::uint32_t dim) {
   return exp(log_softmax(x, dim));
 }
 
 template<>
-Tensor softmax_cross_entropy(const Tensor &x, const Tensor &t, unsigned dim) {
+Tensor softmax_cross_entropy(const Tensor &x, const Tensor &t, std::uint32_t dim) {
   return -sum(t * log_softmax(x, dim), dim);
 }
 
 template<>
 Tensor softmax_cross_entropy(
-    const Tensor &x, const std::vector<unsigned> &ids, unsigned dim) {
+    const Tensor &x, const std::vector<std::uint32_t> &ids, std::uint32_t dim) {
   return pick(-log_softmax(x, dim), ids, dim);
 }
 
@@ -273,7 +273,7 @@ Tensor constant<Tensor>(const Shape &shape, float k, Device &dev) {
 }
 
 template<>
-Tensor identity<Tensor>(unsigned size, Device &dev) {
+Tensor identity<Tensor>(std::uint32_t size, Device &dev) {
   return dev.identity(size);
 }
 

--- a/primitiv/trainer.cc
+++ b/primitiv/trainer.cc
@@ -48,7 +48,7 @@ namespace primitiv {
 void Trainer::load(const std::string &path) {
   messages::Trainer msg;
   ::read_proto(path, msg);
-  std::unordered_map<std::string, unsigned> uint_configs(
+  std::unordered_map<std::string, std::uint32_t> uint_configs(
       msg.uint_configs().begin(), msg.uint_configs().end());
   std::unordered_map<std::string, float> float_configs(
       msg.float_configs().begin(), msg.float_configs().end());
@@ -58,7 +58,7 @@ void Trainer::load(const std::string &path) {
 void Trainer::save(const std::string &path) const {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
-  std::unordered_map<std::string, unsigned> uint_configs;
+  std::unordered_map<std::string, std::uint32_t> uint_configs;
   std::unordered_map<std::string, float> float_configs;
   get_configs(uint_configs, float_configs);
 
@@ -119,7 +119,7 @@ void Trainer::update() {
 }
 
 void Trainer::get_configs(
-    std::unordered_map<std::string, unsigned> &uint_configs,
+    std::unordered_map<std::string, std::uint32_t> &uint_configs,
     std::unordered_map<std::string, float> &float_configs) const {
   uint_configs.insert(std::make_pair("Trainer.epoch", epoch_));
   float_configs.insert(std::make_pair("Trainer.lr_scale", lr_scale_));
@@ -128,7 +128,7 @@ void Trainer::get_configs(
 }
 
 void Trainer::set_configs(
-    const std::unordered_map<std::string, unsigned> &uint_configs,
+    const std::unordered_map<std::string, std::uint32_t> &uint_configs,
     const std::unordered_map<std::string, float> &float_configs) {
 #define SET_CONFIG(dest, cfg, key) { \
   const auto it = cfg.find(key); \

--- a/primitiv/trainer.h
+++ b/primitiv/trainer.h
@@ -1,6 +1,7 @@
 #ifndef PRIMITIV_TRAINER_H_
 #define PRIMITIV_TRAINER_H_
 
+#include <cstdint>
 #include <memory>
 #include <unordered_set>
 #include <primitiv/error.h>
@@ -36,13 +37,13 @@ public:
    * Retrieves current epoch.
    * @return Current epoch.
    */
-  unsigned get_epoch() const { return epoch_; }
+  std::uint32_t get_epoch() const { return epoch_; }
 
   /**
    * Sets current epoch.
    * @param epoch New epoch.
    */
-  void set_epoch(unsigned epoch) { epoch_ = epoch; }
+  void set_epoch(std::uint32_t epoch) { epoch_ = epoch; }
 
   /**
    * Retrieves current learning rate scaling factor.
@@ -119,24 +120,24 @@ public:
 
   /**
    * Gathers configuration values.
-   * @param uint_configs Configurations with unsigned type.
+   * @param uint_configs Configurations with std::uint32_t type.
    * @param float_configs Configurations with float type.
    */
   virtual void get_configs(
-      std::unordered_map<std::string, unsigned> &uint_configs,
+      std::unordered_map<std::string, std::uint32_t> &uint_configs,
       std::unordered_map<std::string, float> &float_configs) const;
 
   /**
    * Sets configuration values.
-   * @param uint_configs Configurations with unsigned type.
+   * @param uint_configs Configurations with std::uint32_t type.
    * @param float_configs Configurations with float type.
    */
   virtual void set_configs(
-      const std::unordered_map<std::string, unsigned> &uint_configs,
+      const std::unordered_map<std::string, std::uint32_t> &uint_configs,
       const std::unordered_map<std::string, float> &float_configs);
 
 private:
-  unsigned epoch_;
+  std::uint32_t epoch_;
   float lr_scale_;
   float l2_strength_;
   float clip_threshold_;

--- a/primitiv/trainer_impl.cc
+++ b/primitiv/trainer_impl.cc
@@ -24,14 +24,14 @@ void SGD::update_parameter(float scale, Parameter &param) {
 }
 
 void SGD::get_configs(
-    std::unordered_map<std::string, unsigned> &uint_configs,
+    std::unordered_map<std::string, std::uint32_t> &uint_configs,
     std::unordered_map<std::string, float> &float_configs) const {
   Trainer::get_configs(uint_configs, float_configs);
   float_configs.insert(std::make_pair("SGD.eta", eta_));
 }
 
 void SGD::set_configs(
-    const std::unordered_map<std::string, unsigned> &uint_configs,
+    const std::unordered_map<std::string, std::uint32_t> &uint_configs,
     const std::unordered_map<std::string, float> &float_configs) {
   Trainer::set_configs(uint_configs, float_configs);
   SET_CONFIG(eta_, float_configs, "SGD.eta");
@@ -52,7 +52,7 @@ void MomentumSGD::update_parameter(float scale, Parameter &param) {
 }
 
 void MomentumSGD::get_configs(
-    std::unordered_map<std::string, unsigned> &uint_configs,
+    std::unordered_map<std::string, std::uint32_t> &uint_configs,
     std::unordered_map<std::string, float> &float_configs) const {
   Trainer::get_configs(uint_configs, float_configs);
   float_configs.insert(std::make_pair("MomentumSGD.eta", eta_));
@@ -60,7 +60,7 @@ void MomentumSGD::get_configs(
 }
 
 void MomentumSGD::set_configs(
-    const std::unordered_map<std::string, unsigned> &uint_configs,
+    const std::unordered_map<std::string, std::uint32_t> &uint_configs,
     const std::unordered_map<std::string, float> &float_configs) {
   Trainer::set_configs(uint_configs, float_configs);
   SET_CONFIG(eta_, float_configs, "MomentumSGD.eta");
@@ -82,7 +82,7 @@ void AdaGrad::update_parameter(float scale, Parameter &param) {
 }
 
 void AdaGrad::get_configs(
-    std::unordered_map<std::string, unsigned> &uint_configs,
+    std::unordered_map<std::string, std::uint32_t> &uint_configs,
     std::unordered_map<std::string, float> &float_configs) const {
   Trainer::get_configs(uint_configs, float_configs);
   float_configs.insert(std::make_pair("AdaGrad.eta", eta_));
@@ -90,7 +90,7 @@ void AdaGrad::get_configs(
 }
 
 void AdaGrad::set_configs(
-    const std::unordered_map<std::string, unsigned> &uint_configs,
+    const std::unordered_map<std::string, std::uint32_t> &uint_configs,
     const std::unordered_map<std::string, float> &float_configs) {
   Trainer::set_configs(uint_configs, float_configs);
   SET_CONFIG(eta_, float_configs, "AdaGrad.eta");
@@ -112,7 +112,7 @@ void RMSProp::update_parameter(float scale, Parameter &param) {
 }
 
 void RMSProp::get_configs(
-    std::unordered_map<std::string, unsigned> &uint_configs,
+    std::unordered_map<std::string, std::uint32_t> &uint_configs,
     std::unordered_map<std::string, float> &float_configs) const {
   Trainer::get_configs(uint_configs, float_configs);
   float_configs.insert(std::make_pair("RMSProp.eta", eta_));
@@ -121,7 +121,7 @@ void RMSProp::get_configs(
 }
 
 void RMSProp::set_configs(
-    const std::unordered_map<std::string, unsigned> &uint_configs,
+    const std::unordered_map<std::string, std::uint32_t> &uint_configs,
     const std::unordered_map<std::string, float> &float_configs) {
   Trainer::set_configs(uint_configs, float_configs);
   SET_CONFIG(eta_, float_configs, "RMSProp.eta");
@@ -150,7 +150,7 @@ void AdaDelta::update_parameter(float scale, Parameter &param) {
 }
 
 void AdaDelta::get_configs(
-    std::unordered_map<std::string, unsigned> &uint_configs,
+    std::unordered_map<std::string, std::uint32_t> &uint_configs,
     std::unordered_map<std::string, float> &float_configs) const {
   Trainer::get_configs(uint_configs, float_configs);
   float_configs.insert(std::make_pair("AdaDelta.rho", rho_));
@@ -158,7 +158,7 @@ void AdaDelta::get_configs(
 }
 
 void AdaDelta::set_configs(
-    const std::unordered_map<std::string, unsigned> &uint_configs,
+    const std::unordered_map<std::string, std::uint32_t> &uint_configs,
     const std::unordered_map<std::string, float> &float_configs) {
   Trainer::set_configs(uint_configs, float_configs);
   SET_CONFIG(rho_, float_configs, "AdaDelta.rho");
@@ -174,7 +174,7 @@ void Adam::configure_parameter(Parameter &param) {
 }
 
 void Adam::update_parameter(float scale, Parameter &param) {
-  const unsigned epoch = get_epoch() + 1;
+  const std::uint32_t epoch = get_epoch() + 1;
   const Tensor &g = param.gradient();
   Tensor &m1 = param.stats("adam-m1");
   Tensor &m2 = param.stats("adam-m2");
@@ -186,7 +186,7 @@ void Adam::update_parameter(float scale, Parameter &param) {
 }
 
 void Adam::get_configs(
-    std::unordered_map<std::string, unsigned> &uint_configs,
+    std::unordered_map<std::string, std::uint32_t> &uint_configs,
     std::unordered_map<std::string, float> &float_configs) const {
   Trainer::get_configs(uint_configs, float_configs);
   float_configs.insert(std::make_pair("Adam.alpha", alpha_));
@@ -196,7 +196,7 @@ void Adam::get_configs(
 }
 
 void Adam::set_configs(
-    const std::unordered_map<std::string, unsigned> &uint_configs,
+    const std::unordered_map<std::string, std::uint32_t> &uint_configs,
     const std::unordered_map<std::string, float> &float_configs) {
   Trainer::set_configs(uint_configs, float_configs);
   SET_CONFIG(alpha_, float_configs, "Adam.alpha");

--- a/primitiv/trainer_impl.h
+++ b/primitiv/trainer_impl.h
@@ -9,10 +9,10 @@ namespace trainers {
 #define DECL_DEFAULTS \
 public: \
   void get_configs( \
-      std::unordered_map<std::string, unsigned> &uint_configs, \
+      std::unordered_map<std::string, std::uint32_t> &uint_configs, \
       std::unordered_map<std::string, float> &float_configs) const override; \
   void set_configs( \
-      const std::unordered_map<std::string, unsigned> &uint_configs, \
+      const std::unordered_map<std::string, std::uint32_t> &uint_configs, \
       const std::unordered_map<std::string, float> &float_configs) override; \
 private: \
   void configure_parameter(Parameter &param) override; \

--- a/test/cuda_device_test.cc
+++ b/test/cuda_device_test.cc
@@ -60,7 +60,7 @@ TEST_F(CUDADeviceTest, CheckDanglingTensor) {
 #ifdef PRIMITIV_BUILD_TESTS_PROBABILISTIC
 TEST_F(CUDADeviceTest, CheckRandomBernoulli) {
   vector<vector<float>> history;
-  for (unsigned i = 0; i < 10; ++i) {
+  for (std::uint32_t i = 0; i < 10; ++i) {
     devices::CUDA dev(0);
     const Tensor x = dev.random_bernoulli(Shape({3, 3}, 3), 0.3);
     const vector<float> x_val = x.to_vector();
@@ -97,7 +97,7 @@ TEST_F(CUDADeviceTest, CheckRandomBernoulliWithSeed) {
 #ifdef PRIMITIV_BUILD_TESTS_PROBABILISTIC
 TEST_F(CUDADeviceTest, CheckRandomUniform) {
   vector<vector<float>> history;
-  for (unsigned i = 0; i < 10; ++i) {
+  for (std::uint32_t i = 0; i < 10; ++i) {
     devices::CUDA dev(0);
     const Tensor x = dev.random_uniform(Shape({2, 2}, 2), -9, 9);
     const vector<float> x_val = x.to_vector();
@@ -132,7 +132,7 @@ TEST_F(CUDADeviceTest, CheckRandomUniformWithSeed) {
 #ifdef PRIMITIV_BUILD_TESTS_PROBABILISTIC
 TEST_F(CUDADeviceTest, CheckRandomNormal) {
   vector<vector<float>> history;
-  for (unsigned i = 0; i < 10; ++i) {
+  for (std::uint32_t i = 0; i < 10; ++i) {
     devices::CUDA dev(0);
     const Tensor x = dev.random_normal(Shape({2, 2}, 2), 1, 3);
     const vector<float> x_val = x.to_vector();
@@ -167,7 +167,7 @@ TEST_F(CUDADeviceTest, CheckRandomNormalWithSeed) {
 #ifdef PRIMITIV_BUILD_TESTS_PROBABILISTIC
 TEST_F(CUDADeviceTest, CheckRandomLogNormal) {
   vector<vector<float>> history;
-  for (unsigned i = 0; i < 10; ++i) {
+  for (std::uint32_t i = 0; i < 10; ++i) {
     devices::CUDA dev(0);
     const Tensor x = dev.random_log_normal(Shape({2, 2}, 2), 1, 3);
     const vector<float> x_val = x.to_vector();

--- a/test/cuda_memory_pool_test.cc
+++ b/test/cuda_memory_pool_test.cc
@@ -27,7 +27,7 @@ TEST_F(CUDAMemoryPoolTest, CheckInvalidNew) {
 
 TEST_F(CUDAMemoryPoolTest, CheckPoolIDs) {
   CUDAMemoryPool pool0(0);
-  std::uint64_t base = pool0.get_pool_id();
+  std::size_t base = pool0.get_pool_id();
 
   CUDAMemoryPool pool1(0);
   EXPECT_EQ(base + 1, pool1.get_pool_id());
@@ -95,7 +95,7 @@ TEST_F(CUDAMemoryPoolTest, CheckInvalidAllocate) {
   CUDA_CALL(::cudaGetDeviceProperties(&prop, 0));
 
   // Calculates the half or more size of the whole memory.
-  std::uint64_t size = 1llu;
+  std::size_t size = 1llu;
   while (size < prop.totalGlobalMem >> 1) size <<= 1;
 
   // rvalue shared pointers immediately releases the raw pointers, so that the
@@ -120,9 +120,9 @@ TEST_F(CUDAMemoryPoolTest, CheckReleaseReservedBlocks) {
   std::cerr << "Total size: " << prop.totalGlobalMem << std::endl;
 
   // Calculates chunk sizes and number of chunks.
-  std::uint64_t size = 1llu;
+  std::size_t size = 1llu;
   while (size < prop.totalGlobalMem >> 3) size <<= 1;
-  unsigned n = 0;
+  std::uint32_t n = 0;
   while (n * size < prop.totalGlobalMem) ++n;
   std::cerr << "Chunk size: " << size << std::endl;
   std::cerr << "#Chunks: " << n << std::endl;
@@ -130,7 +130,7 @@ TEST_F(CUDAMemoryPoolTest, CheckReleaseReservedBlocks) {
 
   // Reserves n-4 chunks.
   std::vector<std::shared_ptr<void>> reserved;
-  for (unsigned i = 0; i < n - 4; ++i) {
+  for (std::uint32_t i = 0; i < n - 4; ++i) {
     EXPECT_NO_THROW(reserved.emplace_back(pool.allocate(size)));
   }
 

--- a/test/function_impl_test.cc
+++ b/test/function_impl_test.cc
@@ -271,7 +271,7 @@ TEST_F(FunctionImplTest, CheckConstant) {
 
 TEST_F(FunctionImplTest, CheckIdentity) {
   struct TestCase {
-    unsigned size;
+    std::uint32_t size;
     Shape shape;
     vector<float> data;
   };
@@ -478,8 +478,8 @@ TEST_F(FunctionImplTest, CheckRandomLogNormal) {
 
 TEST_F(FunctionImplTest, CheckPick) {
   struct TestCase {
-    unsigned dim;
-    vector<unsigned> ids;
+    std::uint32_t dim;
+    vector<std::uint32_t> ids;
     Shape ret_shape;
     vector<float> ret_data;
     vector<float> bw_grad;
@@ -519,7 +519,7 @@ TEST_F(FunctionImplTest, CheckPick) {
 
 TEST_F(FunctionImplTest, CheckSlice) {
   struct TestCase {
-    unsigned dim, lower, upper;
+    std::uint32_t dim, lower, upper;
     Shape ret_shape;
     vector<float> ret_data;
     vector<float> bw_grad;
@@ -571,7 +571,7 @@ TEST_F(FunctionImplTest, CheckSlice) {
 
 TEST_F(FunctionImplTest, CheckConcat) {
   struct TestCase {
-    unsigned dim;
+    std::uint32_t dim;
     Shape ret_shape;
     vector<float> cur_value_data;
     vector<float> cur_grad_data;
@@ -1127,7 +1127,7 @@ TEST_F(FunctionImplTest, CheckSum) {
   // dy/dx = broadcast(1, dim, x.shape[dim])
   setup_1arg();
   struct TestCase {
-    unsigned dim;
+    std::uint32_t dim;
     Shape ret_shape;
     vector<float> ret_data;
   };
@@ -1156,7 +1156,7 @@ TEST_F(FunctionImplTest, CheckLogSumExp) {
   // dy/dx = softmax(x, dim)
   setup_1arg();
   struct TestCase {
-    unsigned dim;
+    std::uint32_t dim;
     Shape ret_shape;
     vector<float> ret_data;
     vector<float> bw_grad;
@@ -1200,7 +1200,7 @@ TEST_F(FunctionImplTest, CheckBroadcast) {
   // dy/dx = sum(1, dim)
   setup_1arg();
   struct TestCase {
-    unsigned dim, size;
+    std::uint32_t dim, size;
     Shape ret_shape;
     vector<float> ret_data;
   };
@@ -1278,8 +1278,8 @@ TEST_F(FunctionImplTest, CheckSoftmaxCrossEntropy) {
 
 TEST_F(FunctionImplTest, CheckSparseSoftmaxCrossEntropy) {
   struct TestCase {
-    unsigned dim;
-    vector<unsigned> ids;
+    std::uint32_t dim;
+    vector<std::uint32_t> ids;
     Shape ret_shape;
     vector<float> ret_data;
     vector<float> bw_grad;

--- a/test/graph_test.cc
+++ b/test/graph_test.cc
@@ -64,8 +64,8 @@ TEST_F(GraphTest, CheckMoveNode) {
 
   Node x1 = operators::zeros<Node>({2, 2});
   ASSERT_TRUE(x1.valid());
-  const unsigned fid = x1.function_id();
-  const unsigned vid = x1.value_id();
+  const std::uint32_t fid = x1.function_id();
+  const std::uint32_t vid = x1.value_id();
 
   // c-tor
   Node x2 = std::move(x1);
@@ -193,7 +193,7 @@ TEST_F(GraphTest, CheckForwardBackward) {
     Shape({2, 2}, 3),
     Shape({1, 2}, 3), Shape({}, 3), {},
   };
-  for (unsigned i = 0; i < nodes.size(); ++i) {
+  for (std::uint32_t i = 0; i < nodes.size(); ++i) {
     EXPECT_EQ(expected_shapes[i], nodes[i].shape());
     EXPECT_EQ(&dev, &nodes[i].device());
   }
@@ -213,7 +213,7 @@ TEST_F(GraphTest, CheckForwardBackward) {
     {18, 4, -10},
     {12},
   };
-  for (unsigned i = 0; i < nodes.size(); ++i) {
+  for (std::uint32_t i = 0; i < nodes.size(); ++i) {
     // This forward method has no effect and only returns the reference to the
     // inner value.
     const Tensor &val = g.forward(nodes[i]);
@@ -238,7 +238,7 @@ TEST_F(GraphTest, CheckForwardBackward) {
     {1, 1, 1}, // 1
     {1}, // 1
   };
-  for (unsigned i = 0; i < nodes.size(); ++i) {
+  for (std::uint32_t i = 0; i < nodes.size(); ++i) {
     const Tensor &val = g.get_gradient(nodes[i]);
     ASSERT_TRUE(val.valid());
     EXPECT_TRUE(vector_match(expected_grads[i], val.to_vector()));
@@ -311,7 +311,7 @@ TEST_F(GraphTest, CheckXor) {
     {h3 * h3, h7 * h7, h7 * h7, h3 * h3},
     {2 * (h3 * h3 + h7 * h7)},
   };
-  for (unsigned i = 0; i < nodes.size(); ++i) {
+  for (std::uint32_t i = 0; i < nodes.size(); ++i) {
     const Tensor &val = g.forward(nodes[i]);
     ASSERT_TRUE(val.valid());
     EXPECT_TRUE(vector_match(expected_values[i], val.to_vector()));
@@ -405,7 +405,7 @@ TEST_F(GraphTest, CheckLSTM) {
     std::cout << name << ": shape=" << value.shape().to_string()
       << ", values=[";
     const vector<float> data = value.to_vector();
-    for (unsigned i = 0; i < data.size(); ++i) {
+    for (std::uint32_t i = 0; i < data.size(); ++i) {
       if (i > 0) std::cout << ',';
       std::cout << data[i];
     }
@@ -504,7 +504,7 @@ TEST_F(GraphTest, CheckConcatLSTM) {
     std::cout << name << ": shape=" << value.shape().to_string()
       << ", values=[";
     const vector<float> data = value.to_vector();
-    for (unsigned i = 0; i < data.size(); ++i) {
+    for (std::uint32_t i = 0; i < data.size(); ++i) {
       if (i > 0) std::cout << ',';
       std::cout << data[i];
     }

--- a/test/initializer_impl_test.cc
+++ b/test/initializer_impl_test.cc
@@ -41,7 +41,7 @@ TEST_F(InitializerImplTest, CheckUniform) {
     {-1, 0, -.5, 1./12},
     {-.70710678, .70710678, 0, 2./12},
   };
-  const unsigned N = 768;
+  const std::uint32_t N = 768;
 
   for (const auto &tc : test_cases) {
     const Uniform init(tc.lower, tc.upper);
@@ -73,7 +73,7 @@ TEST_F(InitializerImplTest, CheckNormal) {
     {3, 2}, {-3, 2},
     {3, .5}, {-3, .5},
   };
-  const unsigned N = 768;
+  const std::uint32_t N = 768;
 
   for (const auto &tc : test_cases) {
     const Normal init(tc.mean, tc.sd);
@@ -94,12 +94,12 @@ TEST_F(InitializerImplTest, CheckNormal) {
 }
 
 TEST_F(InitializerImplTest, CheckIdentity) {
-  const unsigned N = 768;
+  const std::uint32_t N = 768;
   Tensor x = dev.new_tensor_by_constant({N, N}, 0);
   const Identity init;
   init.apply(x);
   const std::vector<float> values = x.to_vector();
-  for (unsigned i = 0; i < N * N; ++i) {
+  for (std::uint32_t i = 0; i < N * N; ++i) {
     EXPECT_EQ(!(i % (N + 1)), values[i]);
   }
 }
@@ -114,7 +114,7 @@ TEST_F(InitializerImplTest, CheckInvalidIdentity) {
 }
 
 TEST_F(InitializerImplTest, CheckXavierUniform) {
-  const unsigned N = 768;
+  const std::uint32_t N = 768;
   Tensor x = dev.new_tensor_by_constant({N, N}, 0);
 
   for (float scale : {.5f, 1.f, 2.f}) {
@@ -151,7 +151,7 @@ TEST_F(InitializerImplTest, CheckInvalidXavierUniform) {
 
 TEST_F(InitializerImplTest, CheckXavierNormal) {
   // NOTE(odashi): This test checks only mean and SD.
-  const unsigned N = 768;
+  const std::uint32_t N = 768;
   Tensor x = dev.new_tensor_by_constant({N, N}, 0);
 
   for (float scale : {.5f, 1.f, 2.f}) {

--- a/test/naive_device_test.cc
+++ b/test/naive_device_test.cc
@@ -55,7 +55,7 @@ TEST_F(NaiveDeviceTest, CheckDanglingTensor) {
 #ifdef PRIMITIV_BUILD_TESTS_PROBABILISTIC
 TEST_F(NaiveDeviceTest, CheckRandomBernoulli) {
   vector<vector<float>> history;
-  for (unsigned i = 0; i < 10; ++i) {
+  for (std::uint32_t i = 0; i < 10; ++i) {
     devices::Naive dev;
     const Tensor x = dev.random_bernoulli(Shape({3, 3}, 3), 0.3);
     const vector<float> x_val = x.to_vector();
@@ -92,7 +92,7 @@ TEST_F(NaiveDeviceTest, CheckRandomBernoulliWithSeed) {
 #ifdef PRIMITIV_BUILD_TESTS_PROBABILISTIC
 TEST_F(NaiveDeviceTest, CheckRandomUniform) {
   vector<vector<float>> history;
-  for (unsigned i = 0; i < 10; ++i) {
+  for (std::uint32_t i = 0; i < 10; ++i) {
     devices::Naive dev;
     const Tensor x = dev.random_uniform(Shape({2, 2}, 2), -9, 9);
     const vector<float> x_val = x.to_vector();
@@ -127,7 +127,7 @@ TEST_F(NaiveDeviceTest, CheckRandomUniformWithSeed) {
 #ifdef PRIMITIV_BUILD_TESTS_PROBABILISTIC
 TEST_F(NaiveDeviceTest, CheckRandomNormal) {
   vector<vector<float>> history;
-  for (unsigned i = 0; i < 10; ++i) {
+  for (std::uint32_t i = 0; i < 10; ++i) {
     devices::Naive dev;
     const Tensor x = dev.random_normal(Shape({2, 2}, 2), 1, 3);
     const vector<float> x_val = x.to_vector();
@@ -172,7 +172,7 @@ TEST_F(NaiveDeviceTest, CheckRandomNormalWithSeed) {
 #ifdef PRIMITIV_BUILD_TESTS_PROBABILISTIC
 TEST_F(NaiveDeviceTest, CheckRandomLogNormal) {
   vector<vector<float>> history;
-  for (unsigned i = 0; i < 10; ++i) {
+  for (std::uint32_t i = 0; i < 10; ++i) {
     devices::Naive dev;
     const Tensor x = dev.random_log_normal(Shape({2, 2}, 2), 1, 3);
     const vector<float> x_val = x.to_vector();

--- a/test/node_test.cc
+++ b/test/node_test.cc
@@ -30,28 +30,28 @@ TEST_F(NodeTest, CheckArgMaxDims) {
   const vector<float> data = {
     0, 1, 2, 6, 7, 8, 3, 4, 5, -3, -4, -5, 0, -1, -2, -6, -7, -8,
   };
-  const vector<vector<unsigned>> expected = {
+  const vector<vector<std::uint32_t>> expected = {
     {2, 2, 2, 0, 0, 0},
     {1, 1, 1, 1, 1, 1},
     {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
   };
   const Node a = operators::input<Node>(Shape({3, 3}, 2), data);
-  for (const unsigned i : {0u, 1u, 2u}) {
+  for (const std::uint32_t i : {0u, 1u, 2u}) {
     EXPECT_TRUE(vector_match(expected[i], a.argmax(i)));
   }
 }
 
 TEST_F(NodeTest, CheckArgMaxLarge) {
   std::mt19937 rng;
-  const vector<unsigned> ns {
+  const vector<std::uint32_t> ns {
     1, 2, 3, 15, 16, 17, 255, 256, 257, 1023, 1024, 1025, 65535, 65536, 65537,
   };
-  for (const unsigned n : ns) {
+  for (const std::uint32_t n : ns) {
     vector<float> data(n);
     std::iota(begin(data), end(data), 0);
     std::shuffle(begin(data), end(data), rng);
     const auto it = std::find(begin(data), end(data), n - 1);
-    const unsigned pos = std::distance(begin(data), it);
+    const std::uint32_t pos = std::distance(begin(data), it);
     const Node a = operators::input<Node>({n}, data);
     EXPECT_EQ(pos, a.argmax(0)[0]);
   }
@@ -61,28 +61,28 @@ TEST_F(NodeTest, CheckArgMinDims) {
   const vector<float> data = {
     3, 4, 5, 0, 1, 2, 6, 7, 8, 0, -1, -2, -6, -7, -8, -3, -4, -5,
   };
-  const vector<vector<unsigned>> expected = {
+  const vector<vector<std::uint32_t>> expected = {
     {0, 0, 0, 2, 2, 2},
     {1, 1, 1, 1, 1, 1},
     {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
   };
   const Node a = operators::input<Node>(Shape({3, 3}, 2), data);
-  for (const unsigned i : {0u, 1u, 2u}) {
+  for (const std::uint32_t i : {0u, 1u, 2u}) {
     EXPECT_TRUE(vector_match(expected[i], a.argmin(i)));
   }
 }
 
 TEST_F(NodeTest, CheckArgMinLarge) {
   std::mt19937 rng;
-  const vector<unsigned> ns {
+  const vector<std::uint32_t> ns {
     1, 2, 3, 15, 16, 17, 255, 256, 257, 1023, 1024, 1025, 65535, 65536, 65537,
   };
-  for (const unsigned n : ns) {
+  for (const std::uint32_t n : ns) {
     vector<float> data(n);
     std::iota(begin(data), end(data), 0);
     std::shuffle(begin(data), end(data), rng);
     const auto it = std::find(begin(data), end(data), 0);
-    const unsigned pos = std::distance(begin(data), it);
+    const std::uint32_t pos = std::distance(begin(data), it);
     const Node a = operators::input<Node>({n}, data);
     EXPECT_EQ(pos, a.argmin(0)[0]);
   }

--- a/test/shape_ops_test.cc
+++ b/test/shape_ops_test.cc
@@ -148,7 +148,7 @@ TEST_F(ShapeOpsTest, CheckInvalidElementwise) {
 
 TEST_F(ShapeOpsTest, CheckSlice) {
   struct TestCase {
-    unsigned dim, lower, upper;
+    std::uint32_t dim, lower, upper;
     Shape input, expected;
   };
   const vector<TestCase> test_cases {
@@ -168,7 +168,7 @@ TEST_F(ShapeOpsTest, CheckSlice) {
 
 TEST_F(ShapeOpsTest, CheckInvalidSlice) {
   struct TestCase {
-    unsigned dim, lower, upper;
+    std::uint32_t dim, lower, upper;
     Shape input;
   };
   const vector<TestCase> test_cases {
@@ -186,7 +186,7 @@ TEST_F(ShapeOpsTest, CheckInvalidSlice) {
 TEST_F(ShapeOpsTest, CheckConcat) {
   struct TestCase {
     vector<Shape> inputs;
-    unsigned dim;
+    std::uint32_t dim;
     Shape expected;
   };
   const vector<TestCase> test_cases {
@@ -212,7 +212,7 @@ TEST_F(ShapeOpsTest, CheckConcat) {
 TEST_F(ShapeOpsTest, CheckInvalidConcat) {
   struct TestCase {
     vector<Shape> inputs;
-    unsigned dim;
+    std::uint32_t dim;
   };
   const vector<TestCase> test_cases {
     {{}, 0},
@@ -232,8 +232,8 @@ TEST_F(ShapeOpsTest, CheckInvalidConcat) {
 TEST_F(ShapeOpsTest, CheckPick) {
   struct TestCase {
     Shape input;
-    unsigned dim;
-    vector<unsigned> ids;
+    std::uint32_t dim;
+    vector<std::uint32_t> ids;
     Shape expected;
   };
   const vector<TestCase> test_cases {
@@ -253,8 +253,8 @@ TEST_F(ShapeOpsTest, CheckPick) {
 TEST_F(ShapeOpsTest, CheckInvalidPick) {
   struct TestCase {
     Shape input;
-    unsigned dim;
-    vector<unsigned> ids;
+    std::uint32_t dim;
+    vector<std::uint32_t> ids;
   };
   const vector<TestCase> test_cases {
      {Shape({2, 2, 2}, 3), 0, {}},

--- a/test/shape_test.cc
+++ b/test/shape_test.cc
@@ -54,7 +54,7 @@ TEST_F(ShapeTest, CheckNewByInitializerList) {
 
 TEST_F(ShapeTest, CheckNewByVector) {
   {
-    const Shape shape(vector<unsigned> {});
+    const Shape shape(vector<std::uint32_t> {});
     EXPECT_EQ(1u, shape[0]);
     EXPECT_EQ(1u, shape[1]);
     EXPECT_EQ(1u, shape[100]);
@@ -64,7 +64,7 @@ TEST_F(ShapeTest, CheckNewByVector) {
     EXPECT_EQ(1u, shape.size());
   }
   {
-    const Shape shape(vector<unsigned> {1, 2, 3}, 4);
+    const Shape shape(vector<std::uint32_t> {1, 2, 3}, 4);
     EXPECT_EQ(1u, shape[0]);
     EXPECT_EQ(2u, shape[1]);
     EXPECT_EQ(3u, shape[2]);
@@ -87,8 +87,8 @@ TEST_F(ShapeTest, CheckInvalidNew) {
   EXPECT_THROW(Shape({}, 0), Error);
   EXPECT_NO_THROW(Shape({1, 2, 3, 4, 5, 6, 7, 8}, 10));
   EXPECT_THROW(Shape({1, 2, 3, 4, 5, 6, 7, 8, 9}, 10), Error);
-  EXPECT_NO_THROW(Shape(vector<unsigned> {1, 2, 3, 4, 5, 6, 7, 8}, 10));
-  EXPECT_THROW(Shape(vector<unsigned> {1, 2, 3, 4, 5, 6, 7, 8, 9}, 10), Error);
+  EXPECT_NO_THROW(Shape(vector<std::uint32_t> {1, 2, 3, 4, 5, 6, 7, 8}, 10));
+  EXPECT_THROW(Shape(vector<std::uint32_t> {1, 2, 3, 4, 5, 6, 7, 8, 9}, 10), Error);
 }
 
 TEST_F(ShapeTest, CheckNumElementsUnderRank) {

--- a/test/tensor_backward_test.cc
+++ b/test/tensor_backward_test.cc
@@ -45,7 +45,7 @@ TEST_F(TensorBackwardTest, CheckSliceNN_1) {
   const vector<float> b_data {1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3};
   const vector<float> y_data {1, 2, 3, 4, 2, 3, 4, 5, 3, 4, 5, 6};
   for (Device *dev : devices) {
-    for (unsigned i : {0, 1, 2, 5, 10}) {
+    for (std::uint32_t i : {0, 1, 2, 5, 10}) {
       Tensor a = dev->new_tensor_by_vector(Shape({2, 2}, 3), a_data);
       const Tensor b = dev->new_tensor_by_vector(Shape({2, 2}, 3), b_data);
       dev->slice_bw(b, i, 0, a);
@@ -59,7 +59,7 @@ TEST_F(TensorBackwardTest, CheckSliceNN_2) {
   const vector<float> b_data {1, 1, 2, 2, 3, 3};
   struct TestCase {
     Shape shape;
-    unsigned dim, offset;
+    std::uint32_t dim, offset;
     vector<float> y_data;
   };
   vector<TestCase> test_cases {
@@ -83,7 +83,7 @@ TEST_F(TensorBackwardTest, CheckSlice1N_1) {
   const vector<float> b_data {1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3};
   const vector<float> y_data {6, 7, 8, 9};
   for (Device *dev : devices) {
-    for (unsigned i : {0, 1, 2, 5, 10}) {
+    for (std::uint32_t i : {0, 1, 2, 5, 10}) {
       Tensor a = dev->new_tensor_by_vector({2, 2}, a_data);
       const Tensor b = dev->new_tensor_by_vector(Shape({2, 2}, 3), b_data);
       dev->slice_bw(b, i, 0, a);
@@ -97,7 +97,7 @@ TEST_F(TensorBackwardTest, CheckSlice1N_2) {
   const vector<float> b_data {1, 1, 2, 2, 3, 3};
   struct TestCase {
     Shape shape;
-    unsigned dim, offset;
+    std::uint32_t dim, offset;
     vector<float> y_data;
   };
   vector<TestCase> test_cases {
@@ -121,7 +121,7 @@ TEST_F(TensorBackwardTest, CheckSliceN1_1) {
   const vector<float> b_data {-1, -2, -3, -4};
   const vector<float> y_data {0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2};
   for (Device *dev : devices) {
-    for (unsigned i : {0, 1, 2, 5, 10}) {
+    for (std::uint32_t i : {0, 1, 2, 5, 10}) {
       Tensor a = dev->new_tensor_by_vector(Shape({2, 2}, 3), a_data);
       const Tensor b = dev->new_tensor_by_vector({2, 2}, b_data);
       dev->slice_bw(b, i, 0, a);
@@ -135,7 +135,7 @@ TEST_F(TensorBackwardTest, CheckSliceN1_2) {
   const vector<float> b_data {-1, -2};
   struct TestCase {
     Shape shape;
-    unsigned dim, offset;
+    std::uint32_t dim, offset;
     vector<float> y_data;
   };
   vector<TestCase> test_cases {
@@ -157,7 +157,7 @@ TEST_F(TensorBackwardTest, CheckSliceN1_2) {
 TEST_F(TensorBackwardTest, CheckInvalidSlice) {
   struct TestCase {
     Shape a_shape, b_shape;
-    unsigned dim, offset;
+    std::uint32_t dim, offset;
     bool ok;
   };
   vector<TestCase> test_cases {
@@ -198,7 +198,7 @@ TEST_F(TensorBackwardTest, CheckCopyAndSlice) {
   const vector<float> b_data {1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3};
   const vector<float> y_data {1, 2, 3, 4, 2, 3, 4, 5, 3, 4, 5, 6};
   for (Device *dev : devices) {
-    for (unsigned i : {0, 1, 2, 5, 10}) {
+    for (std::uint32_t i : {0, 1, 2, 5, 10}) {
       Tensor a = dev->new_tensor_by_vector(Shape({2, 2}, 3), a_data);
       const Tensor b = dev->new_tensor_by_vector(Shape({2, 2}, 3), b_data);
 
@@ -218,8 +218,8 @@ TEST_F(TensorBackwardTest, CheckPickNN) {
   struct TestCase {
     Shape b_shape;
     vector<float> b_data;
-    unsigned dim;
-    vector<unsigned> ids;
+    std::uint32_t dim;
+    vector<std::uint32_t> ids;
     vector<float> y_data;
   };
   const vector<TestCase> test_cases {
@@ -257,8 +257,8 @@ TEST_F(TensorBackwardTest, CheckPickN1) {
   struct TestCase {
     Shape b_shape;
     vector<float> b_data;
-    unsigned dim;
-    vector<unsigned> ids;
+    std::uint32_t dim;
+    vector<std::uint32_t> ids;
     vector<float> y_data;
   };
   const vector<TestCase> test_cases {
@@ -288,8 +288,8 @@ TEST_F(TensorBackwardTest, CheckPick1N) {
   struct TestCase {
     Shape b_shape;
     vector<float> b_data;
-    unsigned dim;
-    vector<unsigned> ids;
+    std::uint32_t dim;
+    vector<std::uint32_t> ids;
     vector<float> y_data;
   };
   const vector<TestCase> test_cases {
@@ -325,8 +325,8 @@ TEST_F(TensorBackwardTest, CheckPick1N) {
 TEST_F(TensorBackwardTest, CheckInvalidPick) {
   struct TestCase {
     Shape a_shape, b_shape;
-    unsigned dim;
-    vector<unsigned> ids;
+    std::uint32_t dim;
+    vector<std::uint32_t> ids;
   };
   vector<TestCase> test_cases {
     // Out-of-range IDs.

--- a/test/tensor_ops_test.cc
+++ b/test/tensor_ops_test.cc
@@ -69,7 +69,7 @@ TEST_F(TensorOpsTest, CheckInputByParameter) {
 
 TEST_F(TensorOpsTest, CheckCopy) {
   vector<float> data(12);
-  unsigned i = 0;
+  std::uint32_t i = 0;
   for (Device *dev : devices) {
     for (Device *dev2 : devices) {
       // Sets different (count-up) data to be copied every time.
@@ -94,7 +94,7 @@ TEST_F(TensorOpsTest, CheckInvalidCopy) {
 
 TEST_F(TensorOpsTest, CheckIdentity) {
   struct TestCase {
-    unsigned size;
+    std::uint32_t size;
     Shape shape;
     vector<float> values;
   };
@@ -124,8 +124,8 @@ TEST_F(TensorOpsTest, CheckInvalidIdentity) {
 TEST_F(TensorOpsTest, CheckPickNN) {
   struct TestCase {
     Shape x_shape;
-    unsigned dim;
-    vector<unsigned> ids;
+    std::uint32_t dim;
+    vector<std::uint32_t> ids;
     Shape y_shape;
     vector<float> values;
   };
@@ -153,7 +153,7 @@ TEST_F(TensorOpsTest, CheckPickNN) {
     for (const TestCase &tc : test_cases) {
       std::cerr << "x_shape=" << tc.x_shape.to_string()
         << ", dim=" << tc.dim << ", ids=[";
-      for (unsigned i = 0; i < tc.ids.size(); ++i) {
+      for (std::uint32_t i = 0; i < tc.ids.size(); ++i) {
         if (i > 0) std::cerr << ',';
         std::cerr << tc.ids[i];
       }
@@ -170,8 +170,8 @@ TEST_F(TensorOpsTest, CheckPickNN) {
 
 TEST_F(TensorOpsTest, CheckInvalidPick) {
   struct TestCase {
-    unsigned dim;
-    vector<unsigned> ids;
+    std::uint32_t dim;
+    vector<std::uint32_t> ids;
   };
   const vector<TestCase> test_cases {
      {0, {}},
@@ -194,7 +194,7 @@ TEST_F(TensorOpsTest, CheckSlice) {
   vector<float> x_data(3 * 3 * 2 * 4);
   std::iota(x_data.begin(), x_data.end(), 0);
   struct TestCase {
-    unsigned dim, lower, upper;
+    std::uint32_t dim, lower, upper;
     Shape shape;
     vector<float> values;
   };
@@ -258,7 +258,7 @@ TEST_F(TensorOpsTest, CheckSlice) {
 }
 
 TEST_F(TensorOpsTest, CheckInvalidSlice) {
-  struct TestCase { unsigned dim, lower, upper; };
+  struct TestCase { std::uint32_t dim, lower, upper; };
   const vector<TestCase> test_cases {
     {0, 0, 0}, {0, 1, 0}, {0, 0, 4}, {0, 3, 4},
     {1, 0, 0}, {1, 1, 0}, {1, 0, 4}, {1, 3, 4},
@@ -303,7 +303,7 @@ TEST_F(TensorOpsTest, CheckConcat5x4) {
     const Tensor b = dev->new_tensor_by_vector({5}, {2, 2, 2, 2, 2});
     const Tensor c = dev->new_tensor_by_vector({5}, {3, 3, 3, 3, 3});
     const Tensor d = dev->new_tensor_by_vector({5}, {4, 4, 4, 4, 4});
-    for (const unsigned i : {0, 1, 2}) {
+    for (const std::uint32_t i : {0, 1, 2}) {
       const Tensor y1 = concat({a, b, c, d}, i);
       const Tensor y2 = concat({&a, &b, &c, &d}, i);
       EXPECT_EQ(shapes[i], y1.shape());
@@ -341,7 +341,7 @@ TEST_F(TensorOpsTest, CheckConcat2_2_2x2) {
   for (Device *dev : devices) {
     const Tensor a = dev->new_tensor_by_vector(Shape({2, 2, 2}, 2), a_data);
     const Tensor b = dev->new_tensor_by_vector(Shape({2, 2, 2}, 2), b_data);
-    for (const unsigned i : {0, 1, 2, 3, 4}) {
+    for (const std::uint32_t i : {0, 1, 2, 3, 4}) {
       const Tensor y1 = concat({a, b}, i);
       const Tensor y2 = concat({&a, &b}, i);
       EXPECT_EQ(shapes[i], y1.shape());
@@ -915,7 +915,7 @@ TEST_F(TensorOpsTest, CheckInvalidArithmeticOps) {
     Shape({2, 2}, 3), Shape({3, 3}, 2), Shape({3, 3}, 3),
   };
   for (Device *dev : devices) {
-    for (unsigned i = 0; i < sa.size(); ++i) {
+    for (std::uint32_t i = 0; i < sa.size(); ++i) {
       const Tensor a = dev->new_tensor_by_vector(
           sa[i], vector<float>(sa[i].size()));
       const Tensor b = dev->new_tensor_by_vector(
@@ -1457,7 +1457,7 @@ TEST_F(TensorOpsTest, CheckSum) {
   };
   for (Device *dev : devices) {
     const Tensor x = dev->new_tensor_by_vector(Shape({2, 2, 2}, 2), x_data);
-    for (unsigned i = 0; i < 4; ++i) {
+    for (std::uint32_t i = 0; i < 4; ++i) {
       const Tensor y = sum(x, i);
       EXPECT_EQ(shape[i], y.shape());
       EXPECT_TRUE(vector_match(y_data[i], y.to_vector()));
@@ -1466,11 +1466,11 @@ TEST_F(TensorOpsTest, CheckSum) {
 }
 
 TEST_F(TensorOpsTest, CheckSum2) {
-  const vector<unsigned> ns {
+  const vector<std::uint32_t> ns {
     1, 2, 3, 15, 16, 17, 255, 256, 257, 1023, 1024, 1025, 65535, 65536, 65537,
   };
   for (Device *dev : devices) {
-    for (const unsigned n : ns) {
+    for (const std::uint32_t n : ns) {
       const Tensor x = dev->new_tensor_by_constant({n}, 1);
       const Tensor y = sum(x, 0);
       EXPECT_EQ(Shape(), y.shape());
@@ -1501,7 +1501,7 @@ TEST_F(TensorOpsTest, CheckLogSumExp) {
   };
   for (Device *dev : devices) {
     const Tensor x = dev->new_tensor_by_vector(Shape({2, 2, 2}, 2), x_data);
-    for (unsigned i = 0; i < 4; ++i) {
+    for (std::uint32_t i = 0; i < 4; ++i) {
       const Tensor y = logsumexp(x, i);
       EXPECT_EQ(shape[i], y.shape());
       EXPECT_TRUE(vector_match(y_data[i], y.to_vector()));
@@ -1510,11 +1510,11 @@ TEST_F(TensorOpsTest, CheckLogSumExp) {
 }
 
 TEST_F(TensorOpsTest, CheckLogSumExp2) {
-  const vector<unsigned> ns {
+  const vector<std::uint32_t> ns {
     1, 2, 3, 15, 16, 17, 255, 256, 257, 1023, 1024, 1025, 65535, 65536, 65537,
   };
   for (Device *dev : devices) {
-    for (const unsigned n : ns) {
+    for (const std::uint32_t n : ns) {
       for (const float k : {-5, -1, 0, 1, 5}) {
         const Tensor x = dev->new_tensor_by_constant({n}, k);
         const Tensor y = logsumexp(x, 0);
@@ -1548,7 +1548,7 @@ TEST_F(TensorOpsTest, CheckLogSoftmax) {
   };
   for (Device *dev : devices) {
     const Tensor x = dev->new_tensor_by_vector(Shape({2, 2, 2}, 2), x_data);
-    for (unsigned i = 0; i < 4; ++i) {
+    for (std::uint32_t i = 0; i < 4; ++i) {
       const Tensor y = log_softmax(x, i);
       EXPECT_EQ(Shape({2, 2, 2}, 2), y.shape());
       EXPECT_TRUE(vector_near(y_data[i], y.to_vector(), 1e-6));
@@ -1557,11 +1557,11 @@ TEST_F(TensorOpsTest, CheckLogSoftmax) {
 }
 
 TEST_F(TensorOpsTest, CheckLogSoftmax2) {
-  const vector<unsigned> ns {
+  const vector<std::uint32_t> ns {
     1, 2, 3, 15, 16, 17, 255, 256, 257, 1023, 1024, 1025, 65535, 65536, 65537,
   };
   for (Device *dev : devices) {
-    for (const unsigned n : ns) {
+    for (const std::uint32_t n : ns) {
       for (const float k : {-5, -1, 0, 1, 5}) {
         const Tensor x = dev->new_tensor_by_constant({n}, k);
         const Tensor y = log_softmax(x, 0);
@@ -1595,7 +1595,7 @@ TEST_F(TensorOpsTest, CheckSoftmax) {
   };
   for (Device *dev : devices) {
     const Tensor x = dev->new_tensor_by_vector(Shape({2, 2, 2}, 2), x_data);
-    for (unsigned i = 0; i < 4; ++i) {
+    for (std::uint32_t i = 0; i < 4; ++i) {
       const Tensor y = softmax(x, i);
       EXPECT_EQ(Shape({2, 2, 2}, 2), y.shape());
       EXPECT_TRUE(vector_near(y_data[i], y.to_vector(), 1e-6));
@@ -1604,11 +1604,11 @@ TEST_F(TensorOpsTest, CheckSoftmax) {
 }
 
 TEST_F(TensorOpsTest, CheckSoftmax2) {
-  const vector<unsigned> ns {
+  const vector<std::uint32_t> ns {
     1, 2, 3, 15, 16, 17, 255, 256, 257, 1023, 1024, 1025, 65535, 65536, 65537,
   };
   for (Device *dev : devices) {
-    for (const unsigned n : ns) {
+    for (const std::uint32_t n : ns) {
       for (const float k : {-5, -1, 0, 1, 5}) {
         const Tensor x = dev->new_tensor_by_constant({n}, k);
         const Tensor y = softmax(x, 0);
@@ -1622,7 +1622,7 @@ TEST_F(TensorOpsTest, CheckSoftmax2) {
 
 TEST_F(TensorOpsTest, CheckBroadcast) {
   struct TestCase {
-    unsigned dim, size;
+    std::uint32_t dim, size;
     Shape shape;
     vector<float> values;
   };
@@ -1644,7 +1644,7 @@ TEST_F(TensorOpsTest, CheckBroadcast) {
 
 TEST_F(TensorOpsTest, CheckBroadcast2) {
   struct TestCase {
-    unsigned dim, size;
+    std::uint32_t dim, size;
     Shape shape;
     vector<float> values;
   };
@@ -1666,7 +1666,7 @@ TEST_F(TensorOpsTest, CheckBroadcast2) {
 
 TEST_F(TensorOpsTest, CheckBroadcast3) {
   struct TestCase {
-    unsigned dim, size;
+    std::uint32_t dim, size;
     Shape shape;
     vector<float> values;
   };
@@ -1737,7 +1737,7 @@ TEST_F(TensorOpsTest, CheckSoftmaxCrossEntropy) {
   };
   const vector<Shape> shape {{1, 3}, {3}};
   for (Device *dev : devices) {
-    for (const unsigned dim : {0, 1}) {
+    for (const std::uint32_t dim : {0, 1}) {
       const Tensor x = dev->new_tensor_by_vector({3, 3}, x_data[dim]);
       const Tensor t = dev->new_tensor_by_vector({3, 3}, t_data[dim]);
       const Tensor y = softmax_cross_entropy(x, t, dim);
@@ -1795,8 +1795,8 @@ TEST_F(TensorOpsTest, CheckInvalidSoftmaxCrossEntropy) {
 TEST_F(TensorOpsTest, CheckSparseSoftmaxCrossEntropy) {
   struct TestCase {
     vector<float> x_data;
-    unsigned dim;
-    vector<unsigned> ids;
+    std::uint32_t dim;
+    vector<std::uint32_t> ids;
     Shape x_shape, y_shape;
     vector<float> y_data;
   };
@@ -1841,14 +1841,14 @@ TEST_F(TensorOpsTest, CheckInvalidSparseSoftmaxCrossEntropy) {
   for (Device *dev : devices) {
     {
       const Tensor x = dev->new_tensor_by_constant({2, 2}, .5);
-      const vector<unsigned> t {2};
+      const vector<std::uint32_t> t {2};
       EXPECT_THROW(softmax_cross_entropy(x, t, 0), Error);
       EXPECT_THROW(softmax_cross_entropy(x, t, 1), Error);
       EXPECT_THROW(softmax_cross_entropy(x, t, 2), Error);
     }
     {
       const Tensor x = dev->new_tensor_by_constant(Shape({2, 2}, 2), .5);
-      const vector<unsigned> t {0, 0, 0};
+      const vector<std::uint32_t> t {0, 0, 0};
       EXPECT_THROW(softmax_cross_entropy(x, t, 0), Error);
       EXPECT_THROW(softmax_cross_entropy(x, t, 1), Error);
       EXPECT_THROW(softmax_cross_entropy(x, t, 2), Error);

--- a/test/tensor_test.cc
+++ b/test/tensor_test.cc
@@ -573,14 +573,14 @@ TEST_F(TensorTest, CheckArgMaxDims) {
   const vector<float> data = {
     0, 1, 2, 6, 7, 8, 3, 4, 5, -3, -4, -5, 0, -1, -2, -6, -7, -8,
   };
-  const vector<vector<unsigned>> expected = {
+  const vector<vector<std::uint32_t>> expected = {
     {2, 2, 2, 0, 0, 0},
     {1, 1, 1, 1, 1, 1},
     {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
   };
   for (Device *dev : devices) {
     const Tensor a = dev->new_tensor_by_vector(Shape({3, 3}, 2), data);
-    for (const unsigned i : {0u, 1u, 2u}) {
+    for (const std::uint32_t i : {0u, 1u, 2u}) {
       EXPECT_TRUE(vector_match(expected[i], a.argmax(i)));
     }
   }
@@ -588,16 +588,16 @@ TEST_F(TensorTest, CheckArgMaxDims) {
 
 TEST_F(TensorTest, CheckArgMaxLarge) {
   std::mt19937 rng;
-  const vector<unsigned> ns {
+  const vector<std::uint32_t> ns {
     1, 2, 3, 15, 16, 17, 255, 256, 257, 1023, 1024, 1025, 65535, 65536, 65537,
   };
   for (Device *dev : devices) {
-    for (const unsigned n : ns) {
+    for (const std::uint32_t n : ns) {
       vector<float> data(n);
       std::iota(begin(data), end(data), 0);
       std::shuffle(begin(data), end(data), rng);
       const auto it = std::find(begin(data), end(data), n - 1);
-      const unsigned pos = std::distance(begin(data), it);
+      const std::uint32_t pos = std::distance(begin(data), it);
       const Tensor a = dev->new_tensor_by_vector({n}, data);
       EXPECT_EQ(pos, a.argmax(0)[0]);
     }
@@ -608,14 +608,14 @@ TEST_F(TensorTest, CheckArgMinDims) {
   const vector<float> data = {
     3, 4, 5, 0, 1, 2, 6, 7, 8, 0, -1, -2, -6, -7, -8, -3, -4, -5,
   };
-  const vector<vector<unsigned>> expected = {
+  const vector<vector<std::uint32_t>> expected = {
     {0, 0, 0, 2, 2, 2},
     {1, 1, 1, 1, 1, 1},
     {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
   };
   for (Device *dev : devices) {
     const Tensor a = dev->new_tensor_by_vector(Shape({3, 3}, 2), data);
-    for (const unsigned i : {0u, 1u, 2u}) {
+    for (const std::uint32_t i : {0u, 1u, 2u}) {
       EXPECT_TRUE(vector_match(expected[i], a.argmin(i)));
     }
   }
@@ -623,16 +623,16 @@ TEST_F(TensorTest, CheckArgMinDims) {
 
 TEST_F(TensorTest, CheckArgMinLarge) {
   std::mt19937 rng;
-  const vector<unsigned> ns {
+  const vector<std::uint32_t> ns {
     1, 2, 3, 15, 16, 17, 255, 256, 257, 1023, 1024, 1025, 65535, 65536, 65537,
   };
   for (Device *dev : devices) {
-    for (const unsigned n : ns) {
+    for (const std::uint32_t n : ns) {
       vector<float> data(n);
       std::iota(begin(data), end(data), 0);
       std::shuffle(begin(data), end(data), rng);
       const auto it = std::find(begin(data), end(data), 0);
-      const unsigned pos = std::distance(begin(data), it);
+      const std::uint32_t pos = std::distance(begin(data), it);
       const Tensor a = dev->new_tensor_by_vector({n}, data);
       EXPECT_EQ(pos, a.argmin(0)[0]);
     }

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -35,7 +35,7 @@ testing::AssertionResult vector_match(
       << "expected.size(): " << expected.size()
       << " != actual.size(): " << actual.size();
   }
-  for (unsigned i = 0; i < expected.size(); ++i) {
+  for (std::uint32_t i = 0; i < expected.size(); ++i) {
     if (expected[i] != actual[i]) {
       return testing::AssertionFailure()
         << "expected[" << i << "]: " << expected[i]
@@ -55,7 +55,7 @@ testing::AssertionResult vector_match(
       << "expected.size(): " << expected.size()
       << " != actual.size(): " << actual.size();
   }
-  for (unsigned i = 0; i < expected.size(); ++i) {
+  for (std::uint32_t i = 0; i < expected.size(); ++i) {
     if (!test_utils::float_eq(expected[i], actual[i])) {
       return testing::AssertionFailure()
         << "expected[" << i << "]: " << expected[i]
@@ -75,7 +75,7 @@ testing::AssertionResult vector_near(
       << "expected.size(): " << expected.size()
       << " != actual.size(): " << actual.size();
   }
-  for (unsigned i = 0; i < expected.size(); ++i) {
+  for (std::uint32_t i = 0; i < expected.size(); ++i) {
     if (!test_utils::float_near(expected[i], actual[i], err)) {
       return testing::AssertionFailure()
         << "expected[" << i << "]: " << expected[i]

--- a/test/trainer_impl_test.cc
+++ b/test/trainer_impl_test.cc
@@ -128,7 +128,7 @@ TEST_F(TrainerImplTest, CheckSGDGetConfigs) {
   trainer.set_weight_decay(4);
   trainer.set_gradient_clipping(5);
 
-  std::unordered_map<std::string, unsigned> uint_configs;
+  std::unordered_map<std::string, std::uint32_t> uint_configs;
   std::unordered_map<std::string, float> float_configs;
   trainer.get_configs(uint_configs, float_configs);
 
@@ -148,7 +148,7 @@ TEST_F(TrainerImplTest, CheckSGDSetConfigs) {
   trainer.set_weight_decay(0);
   trainer.set_gradient_clipping(0);
 
-  std::unordered_map<std::string, unsigned> uint_configs {
+  std::unordered_map<std::string, std::uint32_t> uint_configs {
     std::make_pair("Trainer.epoch", 2),
   };
   std::unordered_map<std::string, float> float_configs {
@@ -183,7 +183,7 @@ TEST_F(TrainerImplTest, CheckSGDUpdate) {
     {9.5099005e-01, 1.9019801e+00, 2.8529701e+00, 3.8039602e+00},
   };
 
-  for (unsigned i = 0; i < 5; ++i) {
+  for (std::uint32_t i = 0; i < 5; ++i) {
     trainer.reset_gradients();
     EXPECT_TRUE(vector_match(
           vector<float>(4, 0), param.gradient().to_vector()));
@@ -223,7 +223,7 @@ TEST_F(TrainerImplTest, CheckMomentumSGDGetConfigs) {
   trainer.set_weight_decay(5);
   trainer.set_gradient_clipping(6);
 
-  std::unordered_map<std::string, unsigned> uint_configs;
+  std::unordered_map<std::string, std::uint32_t> uint_configs;
   std::unordered_map<std::string, float> float_configs;
   trainer.get_configs(uint_configs, float_configs);
 
@@ -244,7 +244,7 @@ TEST_F(TrainerImplTest, CheckMomentumSGDSetConfigs) {
   trainer.set_weight_decay(0);
   trainer.set_gradient_clipping(0);
 
-  std::unordered_map<std::string, unsigned> uint_configs {
+  std::unordered_map<std::string, std::uint32_t> uint_configs {
     std::make_pair("Trainer.epoch", 3),
   };
   std::unordered_map<std::string, float> float_configs {
@@ -290,7 +290,7 @@ TEST_F(TrainerImplTest, CheckMomentumSGDUpdate) {
     {-4.0779430e-03, -8.1558859e-03, -1.2233829e-02, -1.6311772e-02},
   };
 
-  for (unsigned i = 0; i < 5; ++i) {
+  for (std::uint32_t i = 0; i < 5; ++i) {
     trainer.reset_gradients();
     EXPECT_TRUE(vector_match(
           vector<float>(4, 0), param.gradient().to_vector()));
@@ -332,7 +332,7 @@ TEST_F(TrainerImplTest, CheckAdaGradGetConfigs) {
   trainer.set_weight_decay(5);
   trainer.set_gradient_clipping(6);
 
-  std::unordered_map<std::string, unsigned> uint_configs;
+  std::unordered_map<std::string, std::uint32_t> uint_configs;
   std::unordered_map<std::string, float> float_configs;
   trainer.get_configs(uint_configs, float_configs);
 
@@ -353,7 +353,7 @@ TEST_F(TrainerImplTest, CheckAdaGradSetConfigs) {
   trainer.set_weight_decay(0);
   trainer.set_gradient_clipping(0);
 
-  std::unordered_map<std::string, unsigned> uint_configs {
+  std::unordered_map<std::string, std::uint32_t> uint_configs {
     std::make_pair("Trainer.epoch", 3),
   };
   std::unordered_map<std::string, float> float_configs {
@@ -400,7 +400,7 @@ TEST_F(TrainerImplTest, CheckAdaGradUpdate) {
     {4.9984450e+00, 1.9996889e+01, 4.4995335e+01, 7.9993774e+01}
   };
 
-  for (unsigned i = 0; i < 5; ++i) {
+  for (std::uint32_t i = 0; i < 5; ++i) {
     trainer.reset_gradients();
     EXPECT_TRUE(vector_match(
           vector<float>(4, 0), param.gradient().to_vector()));
@@ -443,7 +443,7 @@ TEST_F(TrainerImplTest, CheckRMSPropGetConfigs) {
   trainer.set_weight_decay(6);
   trainer.set_gradient_clipping(7);
 
-  std::unordered_map<std::string, unsigned> uint_configs;
+  std::unordered_map<std::string, std::uint32_t> uint_configs;
   std::unordered_map<std::string, float> float_configs;
   trainer.get_configs(uint_configs, float_configs);
 
@@ -465,7 +465,7 @@ TEST_F(TrainerImplTest, CheckRMSPropSetConfigs) {
   trainer.set_weight_decay(0);
   trainer.set_gradient_clipping(0);
 
-  std::unordered_map<std::string, unsigned> uint_configs {
+  std::unordered_map<std::string, std::uint32_t> uint_configs {
     std::make_pair("Trainer.epoch", 4),
   };
   std::unordered_map<std::string, float> float_configs {
@@ -514,7 +514,7 @@ TEST_F(TrainerImplTest, CheckRMSPropUpdate) {
     {4.0504143e-01, 1.6290820e+00, 3.6721420e+00, 6.5342226e+00}
   };
 
-  for (unsigned i = 0; i < 5; ++i) {
+  for (std::uint32_t i = 0; i < 5; ++i) {
     trainer.reset_gradients();
     EXPECT_TRUE(vector_match(
           vector<float>(4, 0), param.gradient().to_vector()));
@@ -556,7 +556,7 @@ TEST_F(TrainerImplTest, CheckAdaDeltaGetConfigs) {
   trainer.set_weight_decay(5);
   trainer.set_gradient_clipping(6);
 
-  std::unordered_map<std::string, unsigned> uint_configs;
+  std::unordered_map<std::string, std::uint32_t> uint_configs;
   std::unordered_map<std::string, float> float_configs;
   trainer.get_configs(uint_configs, float_configs);
 
@@ -577,7 +577,7 @@ TEST_F(TrainerImplTest, CheckAdaDeltaSetConfigs) {
   trainer.set_weight_decay(0);
   trainer.set_gradient_clipping(0);
 
-  std::unordered_map<std::string, unsigned> uint_configs {
+  std::unordered_map<std::string, std::uint32_t> uint_configs {
     std::make_pair("Trainer.epoch", 3),
   };
   std::unordered_map<std::string, float> float_configs {
@@ -634,7 +634,7 @@ TEST_F(TrainerImplTest, CheckAdaDeltaUpdate) {
     {2.2578933e-01, 9.0401638e-01, 2.0346815e+00, 3.6177848e+00},
   };
 
-  for (unsigned i = 0; i < 5; ++i) {
+  for (std::uint32_t i = 0; i < 5; ++i) {
     trainer.reset_gradients();
     EXPECT_TRUE(vector_match(
           vector<float>(4, 0), param.gradient().to_vector()));
@@ -680,7 +680,7 @@ TEST_F(TrainerImplTest, CheckAdamGetConfigs) {
   trainer.set_weight_decay(7);
   trainer.set_gradient_clipping(8);
 
-  std::unordered_map<std::string, unsigned> uint_configs;
+  std::unordered_map<std::string, std::uint32_t> uint_configs;
   std::unordered_map<std::string, float> float_configs;
   trainer.get_configs(uint_configs, float_configs);
 
@@ -703,7 +703,7 @@ TEST_F(TrainerImplTest, CheckAdamSetConfigs) {
   trainer.set_weight_decay(0);
   trainer.set_gradient_clipping(0);
 
-  std::unordered_map<std::string, unsigned> uint_configs {
+  std::unordered_map<std::string, std::uint32_t> uint_configs {
     std::make_pair("Trainer.epoch", 5),
   };
   std::unordered_map<std::string, float> float_configs {
@@ -764,7 +764,7 @@ TEST_F(TrainerImplTest, CheckAdamUpdate) {
     {4.9880123e-03, 1.9956044e-02, 4.4904096e-02, 7.9832168e-02},
   };
 
-  for (unsigned i = 0; i < 5; ++i) {
+  for (std::uint32_t i = 0; i < 5; ++i) {
     trainer.reset_gradients();
     EXPECT_TRUE(vector_match(
           vector<float>(4, 0), param.gradient().to_vector()));

--- a/test/trainer_test.cc
+++ b/test/trainer_test.cc
@@ -103,7 +103,7 @@ TEST_F(TrainerTest, CheckAddModelWithSubmodels) {
 TEST_F(TrainerTest, CheckEpoch) {
   trainers::SGD trainer;
   ASSERT_EQ(0u, trainer.get_epoch());
-  for (unsigned i = 1; i < 10; ++i) {
+  for (std::uint32_t i = 1; i < 10; ++i) {
     trainer.update();
     EXPECT_EQ(i, trainer.get_epoch());
   }


### PR DESCRIPTION
This PR clarifies the bit representation of some integer values.

* `unsigned` -> `std::uint32_t`
* `int` -> `std::int32_t`
* `std::uint64_t` in `cuda_memory_pool` code -> `std::size_t`

Some variables that are taken by functions out of primitiv keeps the original type.