### PR TITLE
Create a model instance in __cinit__()

### DIFF
--- a/python-primitiv/primitiv/_model.pyx
+++ b/python-primitiv/primitiv/_model.pyx
@@ -59,14 +59,10 @@ cdef class _ModelSubModel:
 cdef class _Model:
 
     def __cinit__(self):
-        self.params = _ModelParameter(self)
-        self.submodels = _ModelSubModel(self)
-
-    def __init__(self):
-        if self.wrapped is not NULL:
-            raise TypeError("__init__() has already been called.")
         self.wrapped = new CppModel()
         _Model.register_wrapper(self.wrapped, self)
+        self.params = _ModelParameter(self)
+        self.submodels = _ModelSubModel(self)
 
     def __dealloc__(self):
         if self.wrapped is not NULL:

--- a/python-primitiv/tests/model.py
+++ b/python-primitiv/tests/model.py
@@ -12,7 +12,8 @@ import tempfile
 
 
 class TestModel(Model):
-    pass
+    def __init__(self):
+        pass
 
 
 class ModelTest(unittest.TestCase):

--- a/python-primitiv/tests/model.py
+++ b/python-primitiv/tests/model.py
@@ -12,6 +12,11 @@ import tempfile
 
 
 class TestModel(Model):
+    # NOTE(vbkaisetsu):
+    # Custom models can be created without calling super().__init__()
+    # function.
+    # This override suppresses calling __init__() function of
+    # the parent Model class to simulate the actual model implementation.
     def __init__(self):
         pass
 


### PR DESCRIPTION
This branch supports creating Model classes without calling `super().__init__()`.