### PR TITLE
Feature/remove pyclass prefix

### DIFF
--- a/python-primitiv/primitiv/__init__.py
+++ b/python-primitiv/primitiv/__init__.py
@@ -1,17 +1,17 @@
-from primitiv._device import _Device as Device
-from primitiv._graph import _Graph as Graph
-from primitiv._initializer import _Initializer as Initializer
-from primitiv._model import _Model as Model
-from primitiv._graph import _Node as Node
-from primitiv._parameter import _Parameter as Parameter
-from primitiv._shape import _Shape as Shape
-from primitiv._tensor import _Tensor as Tensor
-from primitiv._optimizer import _Optimizer as Optimizer
+from primitiv._device import Device
+from primitiv._graph import Graph
+from primitiv._initializer import Initializer
+from primitiv._model import Model
+from primitiv._graph import Node
+from primitiv._parameter import Parameter
+from primitiv._shape import Shape
+from primitiv._tensor import Tensor
+from primitiv._optimizer import Optimizer
 
 from primitiv import devices
 from primitiv import initializers
-from primitiv._operator import _operators as operators
-from primitiv._operator import _tensor_operators as tensor_operators
+from primitiv._operator import operators
+from primitiv._operator import tensor_operators
 from primitiv import optimizers
 from primitiv import config
 

--- a/python-primitiv/primitiv/_device.pxd
+++ b/python-primitiv/primitiv/_device.pxd
@@ -7,10 +7,10 @@ cdef extern from "primitiv/device.h":
         void dump_description() except +
 
 
-cdef class _Device:
+cdef class Device:
     cdef CppDevice *wrapped
     cdef object __weakref__
     @staticmethod
-    cdef void register_wrapper(CppDevice *ptr, _Device wrapper)
+    cdef void register_wrapper(CppDevice *ptr, Device wrapper)
     @staticmethod
-    cdef _Device get_wrapper(CppDevice *ptr)
+    cdef Device get_wrapper(CppDevice *ptr)

--- a/python-primitiv/primitiv/_device.pyx
+++ b/python-primitiv/primitiv/_device.pyx
@@ -11,7 +11,7 @@ from weakref import WeakValueDictionary
 cdef object py_primitiv_device_weak_dict = WeakValueDictionary()
 
 
-cdef class _Device:
+cdef class Device:
     """Interface of the Tensor provider.
 
     """
@@ -25,10 +25,10 @@ cdef class _Device:
         :raises RuntimeError: if the default device is null.
 
         """
-        return _Device.get_wrapper(&CppDevice.get_default())
+        return Device.get_wrapper(&CppDevice.get_default())
 
     @staticmethod
-    def set_default(_Device dev):
+    def set_default(Device dev):
         """Specifies a new default device.
 
         :param dev: Reference of the new default device.
@@ -51,14 +51,14 @@ cdef class _Device:
         raise NotImplementedError(type(self).__name__ + " does not support `__deepcopy__` for now.")
 
     @staticmethod
-    cdef void register_wrapper(CppDevice *ptr, _Device wrapper):
+    cdef void register_wrapper(CppDevice *ptr, Device wrapper):
         if <uintptr_t> ptr in py_primitiv_device_weak_dict:
             raise ValueError("Attempted to register the same C++ object twice.")
         py_primitiv_device_weak_dict[<uintptr_t> ptr] = wrapper
 
     @staticmethod
-    cdef _Device get_wrapper(CppDevice *ptr):
+    cdef Device get_wrapper(CppDevice *ptr):
         # NOTE(vbkaisetsu):
-        # _Device instances should be created and be registered before this
+        # Device instances should be created and be registered before this
         # function is called.
         return py_primitiv_device_weak_dict[<uintptr_t> ptr]

--- a/python-primitiv/primitiv/_graph.pxd
+++ b/python-primitiv/primitiv/_graph.pxd
@@ -56,20 +56,20 @@ cdef extern from "primitiv/graph.h" nogil:
         unsigned num_functions() except +
 
 
-cdef class _Node:
+cdef class Node:
     cdef CppNode wrapped
 
 
-cdef class _Graph:
+cdef class Graph:
     cdef CppGraph *wrapped
     cdef object __weakref__
     @staticmethod
-    cdef void register_wrapper(CppGraph *ptr, _Graph wrapper)
+    cdef void register_wrapper(CppGraph *ptr, Graph wrapper)
     @staticmethod
-    cdef _Graph get_wrapper(CppGraph *ptr)
+    cdef Graph get_wrapper(CppGraph *ptr)
 
 
-cdef inline _Node wrapNode(CppNode wrapped):
-    cdef _Node node = _Node.__new__(_Node)
+cdef inline Node wrapNode(CppNode wrapped):
+    cdef Node node = Node.__new__(Node)
     node.wrapped = wrapped
     return node

--- a/python-primitiv/primitiv/_graph.pyx
+++ b/python-primitiv/primitiv/_graph.pyx
@@ -1,9 +1,9 @@
 from libc.stdint cimport uintptr_t
 from libcpp.vector cimport vector
 
-from primitiv._device cimport _Device
+from primitiv._device cimport Device
 from primitiv._shape cimport wrapShape
-from primitiv._tensor cimport _Tensor
+from primitiv._tensor cimport Tensor
 from primitiv._operator cimport op_pow, op_ipow, op_matmul
 from primitiv.config cimport pystr_to_cppstr, cppstr_to_pystr
 
@@ -21,12 +21,12 @@ import numpy as np
 cdef object py_primitiv_graph_weak_dict = WeakValueDictionary()
 
 
-cdef class _Node:
+cdef class Node:
     """Pointer of a node in the computation graph.
 
     """
 
-    def __init__(self, _Node src = None):
+    def __init__(self, Node src = None):
         if src is None:
             self.wrapped = CppNode()
         else:
@@ -48,7 +48,7 @@ cdef class _Node:
         :rtype: primitiv.Graph
 
         """
-        return _Graph.get_wrapper(&self.wrapped.graph())
+        return Graph.get_wrapper(&self.wrapped.graph())
 
     def function_id(self):
         """Returns the function ID.
@@ -84,7 +84,7 @@ cdef class _Node:
         :rtype: primitiv.Device
 
         """
-        return _Device.get_wrapper(&self.wrapped.device())
+        return Device.get_wrapper(&self.wrapped.device())
 
     def to_float(self):
         """Calculates the value of this node and returns a ``float``.
@@ -187,47 +187,47 @@ cdef class _Node:
 
     def __add__(left, right):
         if isinstance(right, (int, float)):
-            return wrapNode(op_node_add((<_Node> left).wrapped, <float> right))
+            return wrapNode(op_node_add((<Node> left).wrapped, <float> right))
         elif isinstance(left, (int, float)):
-            return wrapNode(op_node_add(<float> left, (<_Node> right).wrapped))
-        elif isinstance(left, _Node) and isinstance(right, _Node):
-            return wrapNode(op_node_add((<_Node> left).wrapped, (<_Node> right).wrapped))
+            return wrapNode(op_node_add(<float> left, (<Node> right).wrapped))
+        elif isinstance(left, Node) and isinstance(right, Node):
+            return wrapNode(op_node_add((<Node> left).wrapped, (<Node> right).wrapped))
         else:
             return NotImplemented
 
     def __sub__(left, right):
         if isinstance(right, (int, float)):
-            return wrapNode(op_node_sub((<_Node> left).wrapped, <float> right))
+            return wrapNode(op_node_sub((<Node> left).wrapped, <float> right))
         elif isinstance(left, (int, float)):
-            return wrapNode(op_node_sub(<float> left, (<_Node> right).wrapped))
-        elif isinstance(left, _Node) and isinstance(right, _Node):
-            return wrapNode(op_node_sub((<_Node> left).wrapped, (<_Node> right).wrapped))
+            return wrapNode(op_node_sub(<float> left, (<Node> right).wrapped))
+        elif isinstance(left, Node) and isinstance(right, Node):
+            return wrapNode(op_node_sub((<Node> left).wrapped, (<Node> right).wrapped))
         else:
             return NotImplemented
 
     def __mul__(left, right):
         if isinstance(right, (int, float)):
-            return wrapNode(op_node_mul((<_Node> left).wrapped, <float> right))
+            return wrapNode(op_node_mul((<Node> left).wrapped, <float> right))
         elif isinstance(left, (int, float)):
-            return wrapNode(op_node_mul(<float> left, (<_Node> right).wrapped))
-        elif isinstance(left, _Node) and isinstance(right, _Node):
-            return wrapNode(op_node_mul((<_Node> left).wrapped, (<_Node> right).wrapped))
+            return wrapNode(op_node_mul(<float> left, (<Node> right).wrapped))
+        elif isinstance(left, Node) and isinstance(right, Node):
+            return wrapNode(op_node_mul((<Node> left).wrapped, (<Node> right).wrapped))
         else:
             return NotImplemented
 
     def __matmul__(left, right):
-        if isinstance(left, _Node) and isinstance(right, _Node):
-            return wrapNode(op_matmul((<_Node> left).wrapped, (<_Node> right).wrapped))
+        if isinstance(left, Node) and isinstance(right, Node):
+            return wrapNode(op_matmul((<Node> left).wrapped, (<Node> right).wrapped))
         else:
             return NotImplemented
 
     def __truediv__(left, right):
         if isinstance(right, (int, float)):
-            return wrapNode(op_node_div((<_Node> left).wrapped, <float> right))
+            return wrapNode(op_node_div((<Node> left).wrapped, <float> right))
         elif isinstance(left, (int, float)):
-            return wrapNode(op_node_div(<float> left, (<_Node> right).wrapped))
-        elif isinstance(left, _Node) and isinstance(right, _Node):
-            return wrapNode(op_node_div((<_Node> left).wrapped, (<_Node> right).wrapped))
+            return wrapNode(op_node_div(<float> left, (<Node> right).wrapped))
+        elif isinstance(left, Node) and isinstance(right, Node):
+            return wrapNode(op_node_div((<Node> left).wrapped, (<Node> right).wrapped))
         else:
             return NotImplemented
 
@@ -235,13 +235,13 @@ cdef class _Node:
         if mod is not None:
             return NotImplemented
         if isinstance(right, int) and -0x80000000 <= right <= 0x7fffffff:
-            return wrapNode(op_ipow((<_Node> left).wrapped, <int> right))
+            return wrapNode(op_ipow((<Node> left).wrapped, <int> right))
         elif isinstance(right, (int, float)):
-            return wrapNode(op_pow((<_Node> left).wrapped, <float> right))
+            return wrapNode(op_pow((<Node> left).wrapped, <float> right))
         elif isinstance(left, (int, float)):
-            return wrapNode(op_pow(<float> left, (<_Node> right).wrapped))
-        elif isinstance(left, _Node) and isinstance(right, _Node):
-            return wrapNode(op_pow((<_Node> left).wrapped, (<_Node> right).wrapped))
+            return wrapNode(op_pow(<float> left, (<Node> right).wrapped))
+        elif isinstance(left, Node) and isinstance(right, Node):
+            return wrapNode(op_pow((<Node> left).wrapped, (<Node> right).wrapped))
         else:
             return NotImplemented
 
@@ -252,7 +252,7 @@ cdef class _Node:
         raise NotImplementedError(type(self).__name__ + " does not support `__deepcopy__` for now.")
 
 
-cdef class _Graph:
+cdef class Graph:
     """Computation graph.
 
     """
@@ -264,7 +264,7 @@ cdef class _Graph:
         if self.wrapped is not NULL:
             raise TypeError("__init__() has already been called.")
         self.wrapped = new CppGraph()
-        _Graph.register_wrapper(self.wrapped, self)
+        Graph.register_wrapper(self.wrapped, self)
 
     def __dealloc__(self):
         if self.wrapped is not NULL:
@@ -280,10 +280,10 @@ cdef class _Graph:
         :raises RuntimeError: if the default graph is null.
 
         """
-        return _Graph.get_wrapper(&CppGraph.get_default())
+        return Graph.get_wrapper(&CppGraph.get_default())
 
     @staticmethod
-    def set_default(_Graph g):
+    def set_default(Graph g):
         """Specifies a new default graph.
 
         :param g: Reference of the new default graph.
@@ -302,7 +302,7 @@ cdef class _Graph:
         self.wrapped.clear()
         return
 
-    def forward(self, _Node node):
+    def forward(self, Node node):
         """Calculates the value of given node.
 
         :param node: Node object specifying the target node.
@@ -320,9 +320,9 @@ cdef class _Graph:
         cdef CppTensor t
         with nogil:
             t = self.wrapped.forward(node.wrapped)
-        return _Tensor.get_wrapper_with_new(new CppTensor(t))
+        return Tensor.get_wrapper_with_new(new CppTensor(t))
 
-    def backward(self, _Node node):
+    def backward(self, Node node):
         """Calculates the backpropagation.
 
         :param node: Node object specifying the output node.
@@ -336,7 +336,7 @@ cdef class _Graph:
             self.wrapped.backward(node.wrapped)
         return
 
-    def get_shape(self, _Node node):
+    def get_shape(self, Node node):
         """Retrieves the shape of the node.
 
         :param node: Node object specifying the target node.
@@ -347,7 +347,7 @@ cdef class _Graph:
         """
         return wrapShape(self.wrapped.get_shape(node.wrapped))
 
-    def get_device(self, _Node node):
+    def get_device(self, Node node):
         """Retrieves the device of the node.
 
         :param node: Node object specifying the target node.
@@ -356,7 +356,7 @@ cdef class _Graph:
         :rtype: primitiv.Device
 
         """
-        return _Device.get_wrapper(&self.wrapped.get_device(node.wrapped))
+        return Device.get_wrapper(&self.wrapped.get_device(node.wrapped))
 
     def dump(self, str fmt):
         """Dump internal graph structure.
@@ -389,14 +389,14 @@ cdef class _Graph:
         raise NotImplementedError(type(self).__name__ + " does not support `__deepcopy__` for now.")
 
     @staticmethod
-    cdef void register_wrapper(CppGraph *ptr, _Graph wrapper):
+    cdef void register_wrapper(CppGraph *ptr, Graph wrapper):
         if <uintptr_t> ptr in py_primitiv_graph_weak_dict:
             raise ValueError("Attempted to register the same C++ object twice.")
         py_primitiv_graph_weak_dict[<uintptr_t> ptr] = wrapper
 
     @staticmethod
-    cdef _Graph get_wrapper(CppGraph *ptr):
+    cdef Graph get_wrapper(CppGraph *ptr):
         # NOTE(vbkaisetsu):
-        # _Graph instances should be created and be registered before this
+        # Graph instances should be created and be registered before this
         # function is called.
         return py_primitiv_graph_weak_dict[<uintptr_t> ptr]

--- a/python-primitiv/primitiv/_initializer.pxd
+++ b/python-primitiv/primitiv/_initializer.pxd
@@ -7,12 +7,12 @@ cdef extern from "primitiv/initializer.h":
         void apply(CppTensor &x) except +
 
 
-cdef class _Initializer:
+cdef class Initializer:
     cdef CppInitializer *wrapped
     cdef CppInitializer *wrapped_newed
 
 
-cdef inline _Initializer wrapInitializer(CppInitializer *wrapped) except +:
-    cdef _Initializer initializer = _Initializer.__new__(_Initializer)
+cdef inline Initializer wrapInitializer(CppInitializer *wrapped) except +:
+    cdef Initializer initializer = Initializer.__new__(Initializer)
     initializer.wrapped = wrapped
     return initializer

--- a/python-primitiv/primitiv/_initializer.pyx
+++ b/python-primitiv/primitiv/_initializer.pyx
@@ -1,12 +1,12 @@
-from primitiv._tensor cimport _Tensor
+from primitiv._tensor cimport Tensor
 
 
-cdef class _Initializer:
+cdef class Initializer:
     """Abstract class to provide parameter initialization algorithms.
 
     """
 
-    def apply(self, _Tensor x):
+    def apply(self, Tensor x):
         """Provides an initialized tensor.
 
         :param x: Tensor object to be initialized.

--- a/python-primitiv/primitiv/_model.pxd
+++ b/python-primitiv/primitiv/_model.pxd
@@ -22,16 +22,16 @@ cdef extern from "primitiv/model.h":
         cppmap[vector[string], CppParameter *] get_trainable_parameters() except +
 
 
-cdef class _Model:
+cdef class Model:
     cdef CppModel *wrapped
     cdef object __weakref__
     cdef object added_parameters
     cdef object added_submodels
     @staticmethod
-    cdef void register_wrapper(CppModel *ptr, _Model wrapper)
+    cdef void register_wrapper(CppModel *ptr, Model wrapper)
     @staticmethod
-    cdef _Model get_wrapper(CppModel *ptr)
+    cdef Model get_wrapper(CppModel *ptr)
 
     # NOTE(vbkaisetsu)
-    # _Model is always created with `new`, so `del_required` is not used.
+    # Model is always created with `new`, so `del_required` is not used.
     # cdef bool del_required

--- a/python-primitiv/primitiv/_operator.pyx
+++ b/python-primitiv/primitiv/_operator.pyx
@@ -1,11 +1,11 @@
 from libcpp.vector cimport vector
 from libcpp cimport bool
 
-from primitiv._device cimport _Device
-from primitiv._shape cimport _Shape, normShape
-from primitiv._tensor cimport _Tensor, CppTensor
-from primitiv._graph cimport _Graph, wrapNode, CppNode, _Node
-from primitiv._parameter cimport _Parameter
+from primitiv._device cimport Device
+from primitiv._shape cimport Shape, normShape
+from primitiv._tensor cimport Tensor, CppTensor
+from primitiv._graph cimport Graph, wrapNode, CppNode, Node
+from primitiv._parameter cimport Parameter
 
 from utils cimport ndarrays_to_vector
 
@@ -13,12 +13,12 @@ cimport numpy as np
 import numpy as np
 
 
-class _operators:
+class operators:
 
     @staticmethod
-    def raw_input(shape, vector[float] data, _Device device = None, _Graph g = None):
+    def raw_input(shape, vector[float] data, Device device = None, Graph g = None):
         if device is None:
-            device = _Device.get_default()
+            device = Device.get_default()
         if g is not None:
             return wrapNode(Node_input_vector(normShape(shape).wrapped, data, device.wrapped[0], g.wrapped[0]))
         else:
@@ -28,7 +28,7 @@ class _operators:
     # This function takes an np.ndarray or a list of np.ndarray
     # instead of a vector.
     @staticmethod
-    def input(data, _Device device = None, _Graph g = None):
+    def input(data, Device device = None, Graph g = None):
         # NOTE(vbkaisetsu, odashi):
         # In this function, we don't check whether each ndarray is empty
         # (i.e., it doesn't have any elements) or not.
@@ -43,204 +43,204 @@ class _operators:
                 raise TypeError("`data` contains no item.")
             if not isinstance(data[0], np.ndarray):
                 raise TypeError("`data` contains other objects than numpy.ndarray.")
-            shape = _Shape(data[0].shape, len(data))
+            shape = Shape(data[0].shape, len(data))
         else:
             raise TypeError("`data` has incorrect type.")
-        return _operators.raw_input(shape, ndarrays_to_vector(data), device, g)
+        return operators.raw_input(shape, ndarrays_to_vector(data), device, g)
 
 
     @staticmethod
-    def parameter(_Parameter param, _Graph g = None):
+    def parameter(Parameter param, Graph g = None):
         if g is not None:
             return wrapNode(Node_parameter(param.wrapped[0], g.wrapped[0]))
         else:
             return wrapNode(Node_parameter(param.wrapped[0]))
 
     @staticmethod
-    def copy(_Node x, _Device device = None):
+    def copy(Node x, Device device = None):
         if device is None:
-            device = _Device.get_default()
+            device = Device.get_default()
         return wrapNode(op_copy(x.wrapped, device.wrapped[0]))
 
     @staticmethod
-    def pick(_Node x, vector[unsigned] ids, unsigned dim):
+    def pick(Node x, vector[unsigned] ids, unsigned dim):
         return wrapNode(op_pick(x.wrapped, ids, dim))
 
     @staticmethod
-    def slice(_Node x, unsigned dim, unsigned lower, unsigned upper):
+    def slice(Node x, unsigned dim, unsigned lower, unsigned upper):
         return wrapNode(op_slice(x.wrapped, dim, lower, upper))
 
     @staticmethod
     def concat(xs, unsigned dim):
         cdef vector[CppNode] vec
-        cdef _Node x
+        cdef Node x
         for x in xs:
             vec.push_back(x.wrapped)
         return wrapNode(op_concat(vec, dim))
 
     @staticmethod
-    def reshape(_Node x, _Shape new_shape):
+    def reshape(Node x, Shape new_shape):
         return wrapNode(op_reshape(x.wrapped, new_shape.wrapped))
 
     @staticmethod
-    def flatten(_Node x):
+    def flatten(Node x):
         return wrapNode(op_flatten(x.wrapped))
 
     @staticmethod
-    def transpose(_Node x):
+    def transpose(Node x):
         return wrapNode(op_transpose(x.wrapped))
 
     @staticmethod
-    def matmul(_Node a, _Node b):
+    def matmul(Node a, Node b):
         return wrapNode(op_matmul(a.wrapped, b.wrapped))
 
     @staticmethod
-    def sqrt(_Node x):
+    def sqrt(Node x):
         return wrapNode(op_sqrt(x.wrapped))
 
     @staticmethod
-    def exp(_Node x):
+    def exp(Node x):
         return wrapNode(op_exp(x.wrapped))
 
     @staticmethod
-    def log(_Node x):
+    def log(Node x):
         return wrapNode(op_log(x.wrapped))
 
     @staticmethod
     def pow(x, k):
-        if isinstance(x, _Node) and isinstance(k, int) and -0x80000000 <= k <= 0x7fffffff:
-            return wrapNode(op_ipow((<_Node> x).wrapped, <int> k))
-        elif isinstance(x, _Node) and isinstance(k, (int, float)):
-            return wrapNode(op_pow((<_Node> x).wrapped, <float> k))
-        elif isinstance(x, (int, float)) and isinstance(k, _Node):
-            return wrapNode(op_pow(<float> x, (<_Node> k).wrapped))
-        elif isinstance(x, _Node) and isinstance(k, _Node):
-            return wrapNode(op_pow((<_Node> x).wrapped, (<_Node> k).wrapped))
+        if isinstance(x, Node) and isinstance(k, int) and -0x80000000 <= k <= 0x7fffffff:
+            return wrapNode(op_ipow((<Node> x).wrapped, <int> k))
+        elif isinstance(x, Node) and isinstance(k, (int, float)):
+            return wrapNode(op_pow((<Node> x).wrapped, <float> k))
+        elif isinstance(x, (int, float)) and isinstance(k, Node):
+            return wrapNode(op_pow(<float> x, (<Node> k).wrapped))
+        elif isinstance(x, Node) and isinstance(k, Node):
+            return wrapNode(op_pow((<Node> x).wrapped, (<Node> k).wrapped))
         else:
             raise TypeError("`x` or `k` has incorrect type.")
 
     @staticmethod
-    def tanh(_Node x):
+    def tanh(Node x):
         return wrapNode(op_tanh(x.wrapped))
 
     @staticmethod
-    def sigmoid(_Node x):
+    def sigmoid(Node x):
         return wrapNode(op_sigmoid(x.wrapped))
 
     @staticmethod
-    def softplus(_Node x):
+    def softplus(Node x):
         return wrapNode(op_softplus(x.wrapped))
 
     @staticmethod
-    def sin(_Node x):
+    def sin(Node x):
         return wrapNode(op_sin(x.wrapped))
 
     @staticmethod
-    def cos(_Node x):
+    def cos(Node x):
         return wrapNode(op_cos(x.wrapped))
 
     @staticmethod
-    def tan(_Node x):
+    def tan(Node x):
         return wrapNode(op_tan(x.wrapped))
 
     @staticmethod
-    def relu(_Node x):
+    def relu(Node x):
         return wrapNode(op_relu(x.wrapped))
 
     @staticmethod
-    def lrelu(_Node x):
+    def lrelu(Node x):
         return wrapNode(op_lrelu(x.wrapped))
 
     @staticmethod
-    def prelu(_Node x, float a):
+    def prelu(Node x, float a):
         return wrapNode(op_prelu(x.wrapped, a))
 
     @staticmethod
-    def elu(_Node x, float a):
+    def elu(Node x, float a):
         return wrapNode(op_elu(x.wrapped, a))
 
     @staticmethod
-    def selu(_Node x, float a, float s):
+    def selu(Node x, float a, float s):
         return wrapNode(op_selu(x.wrapped, a, s))
 
     @staticmethod
     def sum(x, dim = None):
         cdef vector[CppNode] xs
-        cdef _Node node
+        cdef Node node
         if isinstance(x, list):
             for node in x:
                 xs.push_back(node.wrapped)
             return wrapNode(Node_sum_container(xs))
         else:
-            return wrapNode(Node_sum((<_Node> x).wrapped, <unsigned> dim))
+            return wrapNode(Node_sum((<Node> x).wrapped, <unsigned> dim))
 
     @staticmethod
     def mean(x, dim = None):
         cdef vector[CppNode] xs
-        cdef _Node node
+        cdef Node node
         if isinstance(x, list):
             for node in x:
                 xs.push_back(node.wrapped)
             return wrapNode(Node_mean_container(xs))
         else:
-            return wrapNode(Node_mean((<_Node> x).wrapped, <unsigned> dim))
+            return wrapNode(Node_mean((<Node> x).wrapped, <unsigned> dim))
 
     @staticmethod
-    def broadcast(_Node x, unsigned dim, unsigned size):
+    def broadcast(Node x, unsigned dim, unsigned size):
         return wrapNode(op_broadcast(x.wrapped, dim, size))
 
     @staticmethod
-    def logsumexp(_Node x, unsigned dim):
+    def logsumexp(Node x, unsigned dim):
         return wrapNode(op_logsumexp(x.wrapped, dim))
 
     @staticmethod
-    def log_softmax(_Node x, unsigned dim):
+    def log_softmax(Node x, unsigned dim):
         return wrapNode(op_log_softmax(x.wrapped, dim))
 
     @staticmethod
-    def softmax(_Node x, unsigned dim):
+    def softmax(Node x, unsigned dim):
         return wrapNode(op_softmax(x.wrapped, dim))
 
     @staticmethod
-    def softmax_cross_entropy(_Node x, t, unsigned dim):
-        if isinstance(t, _Node):
-            return wrapNode(op_softmax_cross_entropy(x.wrapped, (<_Node> t).wrapped, dim))
+    def softmax_cross_entropy(Node x, t, unsigned dim):
+        if isinstance(t, Node):
+            return wrapNode(op_softmax_cross_entropy(x.wrapped, (<Node> t).wrapped, dim))
         elif isinstance(t, list):
             return wrapNode(op_softmax_cross_entropy(x.wrapped, <vector[unsigned]> t, dim))
         else:
             raise TypeError("`t` has incorrect type.")
 
     @staticmethod
-    def constant(shape, float k, _Device device = None, _Graph g = None):
+    def constant(shape, float k, Device device = None, Graph g = None):
         if device is None:
-            device = _Device.get_default()
+            device = Device.get_default()
         if g is None:
             return wrapNode(op_constant[CppNode](normShape(shape).wrapped, k, device.wrapped[0]))
         else:
             return wrapNode(op_constant(normShape(shape).wrapped, k, device.wrapped[0], g.wrapped[0]))
 
     @staticmethod
-    def zeros(shape, _Device device = None, _Graph g = None):
+    def zeros(shape, Device device = None, Graph g = None):
         if device is None:
-            device = _Device.get_default()
+            device = Device.get_default()
         if g is None:
             return wrapNode(op_zeros[CppNode](normShape(shape).wrapped, device.wrapped[0]))
         else:
             return wrapNode(op_zeros(normShape(shape).wrapped, device.wrapped[0], g.wrapped[0]))
 
     @staticmethod
-    def ones(shape, _Device device = None, _Graph g = None):
+    def ones(shape, Device device = None, Graph g = None):
         if device is None:
-            device = _Device.get_default()
+            device = Device.get_default()
         if g is None:
             return wrapNode(op_ones[CppNode](normShape(shape).wrapped, device.wrapped[0]))
         else:
             return wrapNode(op_ones(normShape(shape).wrapped, device.wrapped[0], g.wrapped[0]))
 
     @staticmethod
-    def identity(unsigned size, _Device device = None, _Graph g = None):
+    def identity(unsigned size, Device device = None, Graph g = None):
         if device is None:
-            device = _Device.get_default()
+            device = Device.get_default()
         if g is None:
             return wrapNode(op_identity[CppNode](size, device.wrapped[0]))
         else:
@@ -248,81 +248,81 @@ class _operators:
 
     class batch:
         @staticmethod
-        def sum(_Node x):
+        def sum(Node x):
             return wrapNode(op_batch_sum[CppNode](x.wrapped))
 
         @staticmethod
-        def mean(_Node x):
+        def mean(Node x):
             return wrapNode(op_batch_mean[CppNode](x.wrapped))
 
         @staticmethod
-        def normalize(_Node x):
+        def normalize(Node x):
             return wrapNode(op_batch_normalize[CppNode](x.wrapped))
 
     class random:
         @staticmethod
-        def bernoulli(shape, float p, _Device device = None, _Graph g = None):
+        def bernoulli(shape, float p, Device device = None, Graph g = None):
             if device is None:
-                device = _Device.get_default()
+                device = Device.get_default()
             if g is None:
                 return wrapNode(op_random_bernoulli[CppNode](normShape(shape).wrapped, p, device.wrapped[0]))
             else:
                 return wrapNode(op_random_bernoulli(normShape(shape).wrapped, p, device.wrapped[0], g.wrapped[0]))
 
         @staticmethod
-        def uniform(shape, float lower, float upper, _Device device = None, _Graph g = None):
+        def uniform(shape, float lower, float upper, Device device = None, Graph g = None):
             if device is None:
-                device = _Device.get_default()
+                device = Device.get_default()
             if g is None:
                 return wrapNode(op_random_uniform[CppNode](normShape(shape).wrapped, lower, upper, device.wrapped[0]))
             else:
                 return wrapNode(op_random_uniform(normShape(shape).wrapped, lower, upper, device.wrapped[0], g.wrapped[0]))
 
         @staticmethod
-        def normal(shape, float mean, float sd, _Device device = None, _Graph g = None):
+        def normal(shape, float mean, float sd, Device device = None, Graph g = None):
             if device is None:
-                device = _Device.get_default()
+                device = Device.get_default()
             if g is None:
                 return wrapNode(op_random_normal[CppNode](normShape(shape).wrapped, mean, sd, device.wrapped[0]))
             else:
                 return wrapNode(op_random_normal(normShape(shape).wrapped, mean, sd, device.wrapped[0], g.wrapped[0]))
 
         @staticmethod
-        def log_normal(shape, float mean, float sd, _Device device = None, _Graph g = None):
+        def log_normal(shape, float mean, float sd, Device device = None, Graph g = None):
             if device is None:
-                device = _Device.get_default()
+                device = Device.get_default()
             if g is None:
                 return wrapNode(op_random_log_normal[CppNode](normShape(shape).wrapped, mean, sd, device.wrapped[0]))
             else:
                 return wrapNode(op_random_log_normal(normShape(shape).wrapped, mean, sd, device.wrapped[0], g.wrapped[0]))
 
         @staticmethod
-        def gumbel(shape, float mu, float beta, _Device device = None, _Graph g = None):
+        def gumbel(shape, float mu, float beta, Device device = None, Graph g = None):
             if device is None:
-                device = _Device.get_default()
+                device = Device.get_default()
             if g is None:
                 return wrapNode(op_random_gumbel[CppNode](normShape(shape).wrapped, mu, beta, device.wrapped[0]))
             else:
                 return wrapNode(op_random_gumbel(normShape(shape).wrapped, mu, beta, device.wrapped[0], g.wrapped[0]))
 
     @staticmethod
-    def dropout(_Node x, float rate, bool enabled):
+    def dropout(Node x, float rate, bool enabled):
         return wrapNode(op_dropout(x.wrapped, rate, enabled))
 
 
-class _tensor_operators:
+class tensor_operators:
 
     @staticmethod
-    def raw_input(shape, vector[float] data, _Device device = None):
+    def raw_input(shape, vector[float] data, Device device = None):
         if device is None:
-            device = _Device.get_default()
-        return _Tensor.get_wrapper_with_new(new CppTensor(Tensor_input_vector(normShape(shape).wrapped, data, device.wrapped[0])))
+            device = Device.get_default()
+        return Tensor.get_wrapper_with_new(new CppTensor(Tensor_input_vector(normShape(shape).wrapped, data, device.wrapped[0])))
 
     # NOTE(vbkaisetsu)
     # This function takes an np.ndarray or a list of np.ndarray
     # instead of a vector.
     @staticmethod
-    def input(data, _Device device = None):
+    def input(data, Device device = None):
         # NOTE(vbkaisetsu, odashi):
         # In this function, we don't check whether each ndarray is empty
         # (i.e., it doesn't have any elements) or not.
@@ -337,237 +337,237 @@ class _tensor_operators:
                 raise TypeError("`data` contains no item.")
             if not isinstance(data[0], np.ndarray):
                 raise TypeError("`data` contains other objects than numpy.ndarray.")
-            shape = _Shape(data[0].shape, len(data))
+            shape = Shape(data[0].shape, len(data))
         else:
             raise TypeError("`data` has incorrect type.")
-        return _tensor_operators.raw_input(shape, ndarrays_to_vector(data), device)
+        return tensor_operators.raw_input(shape, ndarrays_to_vector(data), device)
 
     @staticmethod
-    def parameter(_Parameter param):
-        return _Tensor.get_wrapper_with_new(new CppTensor(Tensor_parameter(param.wrapped[0])))
+    def parameter(Parameter param):
+        return Tensor.get_wrapper_with_new(new CppTensor(Tensor_parameter(param.wrapped[0])))
 
     @staticmethod
-    def copy(_Tensor x, _Device device = None):
+    def copy(Tensor x, Device device = None):
         if device is None:
-            device = _Device.get_default()
-        return _Tensor.get_wrapper_with_new(new CppTensor(op_copy(x.wrapped[0], device.wrapped[0])))
+            device = Device.get_default()
+        return Tensor.get_wrapper_with_new(new CppTensor(op_copy(x.wrapped[0], device.wrapped[0])))
 
     @staticmethod
-    def pick(_Tensor x, vector[unsigned] ids, unsigned dim):
-        return _Tensor.get_wrapper_with_new(new CppTensor(op_pick(x.wrapped[0], ids, dim)))
+    def pick(Tensor x, vector[unsigned] ids, unsigned dim):
+        return Tensor.get_wrapper_with_new(new CppTensor(op_pick(x.wrapped[0], ids, dim)))
 
     @staticmethod
-    def slice(_Tensor x, unsigned dim, unsigned lower, unsigned upper):
-        return _Tensor.get_wrapper_with_new(new CppTensor(op_slice(x.wrapped[0], dim, lower, upper)))
+    def slice(Tensor x, unsigned dim, unsigned lower, unsigned upper):
+        return Tensor.get_wrapper_with_new(new CppTensor(op_slice(x.wrapped[0], dim, lower, upper)))
 
     @staticmethod
     def concat(xs, unsigned dim):
         cdef vector[CppTensor] vec
-        cdef _Tensor x
+        cdef Tensor x
         for x in xs:
             vec.push_back(x.wrapped[0])
-        return _Tensor.get_wrapper_with_new(new CppTensor(op_concat(vec, dim)))
+        return Tensor.get_wrapper_with_new(new CppTensor(op_concat(vec, dim)))
 
     @staticmethod
-    def reshape(_Tensor x, _Shape new_shape):
-        return _Tensor.get_wrapper_with_new(new CppTensor(op_reshape(x.wrapped[0], new_shape.wrapped)))
+    def reshape(Tensor x, Shape new_shape):
+        return Tensor.get_wrapper_with_new(new CppTensor(op_reshape(x.wrapped[0], new_shape.wrapped)))
 
     @staticmethod
-    def flatten(_Tensor x):
-        return _Tensor.get_wrapper_with_new(new CppTensor(op_flatten(x.wrapped[0])))
+    def flatten(Tensor x):
+        return Tensor.get_wrapper_with_new(new CppTensor(op_flatten(x.wrapped[0])))
 
     @staticmethod
-    def transpose(_Tensor x):
-        return _Tensor.get_wrapper_with_new(new CppTensor(op_transpose(x.wrapped[0])))
+    def transpose(Tensor x):
+        return Tensor.get_wrapper_with_new(new CppTensor(op_transpose(x.wrapped[0])))
 
     @staticmethod
-    def matmul(_Tensor a, _Tensor b):
-        return _Tensor.get_wrapper_with_new(new CppTensor(op_matmul(a.wrapped[0], b.wrapped[0])))
+    def matmul(Tensor a, Tensor b):
+        return Tensor.get_wrapper_with_new(new CppTensor(op_matmul(a.wrapped[0], b.wrapped[0])))
 
     @staticmethod
-    def sqrt(_Tensor x):
-        return _Tensor.get_wrapper_with_new(new CppTensor(op_sqrt(x.wrapped[0])))
+    def sqrt(Tensor x):
+        return Tensor.get_wrapper_with_new(new CppTensor(op_sqrt(x.wrapped[0])))
 
     @staticmethod
-    def exp(_Tensor x):
-        return _Tensor.get_wrapper_with_new(new CppTensor(op_exp(x.wrapped[0])))
+    def exp(Tensor x):
+        return Tensor.get_wrapper_with_new(new CppTensor(op_exp(x.wrapped[0])))
 
     @staticmethod
-    def log(_Tensor x):
-        return _Tensor.get_wrapper_with_new(new CppTensor(op_log(x.wrapped[0])))
+    def log(Tensor x):
+        return Tensor.get_wrapper_with_new(new CppTensor(op_log(x.wrapped[0])))
 
     @staticmethod
     def pow(x, k):
-        if isinstance(x, _Tensor) and isinstance(k, int) and -0x80000000 <= k <= 0x7fffffff:
-            return _Tensor.get_wrapper_with_new(new CppTensor(op_ipow((<_Tensor> x).wrapped[0], <int> k)))
-        elif isinstance(x, _Tensor) and isinstance(k, (int, float)):
-            return _Tensor.get_wrapper_with_new(new CppTensor(op_pow((<_Tensor> x).wrapped[0], <float> k)))
-        elif isinstance(x, (int, float)) and isinstance(k, _Tensor):
-            return _Tensor.get_wrapper_with_new(new CppTensor(op_pow(<float> x, (<_Tensor> k).wrapped[0])))
-        elif isinstance(x, _Tensor) and isinstance(k, _Tensor):
-            return _Tensor.get_wrapper_with_new(new CppTensor(op_pow((<_Tensor> x).wrapped[0], (<_Tensor> k).wrapped[0])))
+        if isinstance(x, Tensor) and isinstance(k, int) and -0x80000000 <= k <= 0x7fffffff:
+            return Tensor.get_wrapper_with_new(new CppTensor(op_ipow((<Tensor> x).wrapped[0], <int> k)))
+        elif isinstance(x, Tensor) and isinstance(k, (int, float)):
+            return Tensor.get_wrapper_with_new(new CppTensor(op_pow((<Tensor> x).wrapped[0], <float> k)))
+        elif isinstance(x, (int, float)) and isinstance(k, Tensor):
+            return Tensor.get_wrapper_with_new(new CppTensor(op_pow(<float> x, (<Tensor> k).wrapped[0])))
+        elif isinstance(x, Tensor) and isinstance(k, Tensor):
+            return Tensor.get_wrapper_with_new(new CppTensor(op_pow((<Tensor> x).wrapped[0], (<Tensor> k).wrapped[0])))
         else:
             raise TypeError("`x` or `k` has incorrect type.")
 
     @staticmethod
-    def tanh(_Tensor x):
-        return _Tensor.get_wrapper_with_new(new CppTensor(op_tanh(x.wrapped[0])))
+    def tanh(Tensor x):
+        return Tensor.get_wrapper_with_new(new CppTensor(op_tanh(x.wrapped[0])))
 
     @staticmethod
-    def sigmoid(_Tensor x):
-        return _Tensor.get_wrapper_with_new(new CppTensor(op_sigmoid(x.wrapped[0])))
+    def sigmoid(Tensor x):
+        return Tensor.get_wrapper_with_new(new CppTensor(op_sigmoid(x.wrapped[0])))
 
     @staticmethod
-    def softplus(_Tensor x):
-        return _Tensor.get_wrapper_with_new(new CppTensor(op_softplus(x.wrapped[0])))
+    def softplus(Tensor x):
+        return Tensor.get_wrapper_with_new(new CppTensor(op_softplus(x.wrapped[0])))
 
     @staticmethod
-    def sin(_Tensor x):
-        return _Tensor.get_wrapper_with_new(new CppTensor(op_sin(x.wrapped[0])))
+    def sin(Tensor x):
+        return Tensor.get_wrapper_with_new(new CppTensor(op_sin(x.wrapped[0])))
 
     @staticmethod
-    def cos(_Tensor x):
-        return _Tensor.get_wrapper_with_new(new CppTensor(op_cos(x.wrapped[0])))
+    def cos(Tensor x):
+        return Tensor.get_wrapper_with_new(new CppTensor(op_cos(x.wrapped[0])))
 
     @staticmethod
-    def tan(_Tensor x):
-        return _Tensor.get_wrapper_with_new(new CppTensor(op_tan(x.wrapped[0])))
+    def tan(Tensor x):
+        return Tensor.get_wrapper_with_new(new CppTensor(op_tan(x.wrapped[0])))
 
     @staticmethod
-    def relu(_Tensor x):
-        return _Tensor.get_wrapper_with_new(new CppTensor(op_relu(x.wrapped[0])))
+    def relu(Tensor x):
+        return Tensor.get_wrapper_with_new(new CppTensor(op_relu(x.wrapped[0])))
 
     @staticmethod
-    def lrelu(_Tensor x):
-        return _Tensor.get_wrapper_with_new(new CppTensor(op_lrelu(x.wrapped[0])))
+    def lrelu(Tensor x):
+        return Tensor.get_wrapper_with_new(new CppTensor(op_lrelu(x.wrapped[0])))
 
     @staticmethod
-    def prelu(_Tensor x, float a):
-        return _Tensor.get_wrapper_with_new(new CppTensor(op_prelu(x.wrapped[0], a)))
+    def prelu(Tensor x, float a):
+        return Tensor.get_wrapper_with_new(new CppTensor(op_prelu(x.wrapped[0], a)))
 
     @staticmethod
-    def elu(_Tensor x, float a):
-        return _Tensor.get_wrapper_with_new(new CppTensor(op_elu(x.wrapped[0], a)))
+    def elu(Tensor x, float a):
+        return Tensor.get_wrapper_with_new(new CppTensor(op_elu(x.wrapped[0], a)))
 
     @staticmethod
-    def selu(_Tensor x, float a, float s):
-        return _Tensor.get_wrapper_with_new(new CppTensor(op_selu(x.wrapped[0], a, s)))
+    def selu(Tensor x, float a, float s):
+        return Tensor.get_wrapper_with_new(new CppTensor(op_selu(x.wrapped[0], a, s)))
 
     @staticmethod
     def sum(x, dim = None):
         cdef vector[CppTensor] xs
-        cdef _Tensor t
+        cdef Tensor t
         if isinstance(x, list):
             for t in x:
                 xs.push_back(t.wrapped[0])
-            return _Tensor.get_wrapper_with_new(new CppTensor(Tensor_sum_container(xs)))
+            return Tensor.get_wrapper_with_new(new CppTensor(Tensor_sum_container(xs)))
         else:
-            return _Tensor.get_wrapper_with_new(new CppTensor(Tensor_sum((<_Tensor> x).wrapped[0], <unsigned> dim)))
+            return Tensor.get_wrapper_with_new(new CppTensor(Tensor_sum((<Tensor> x).wrapped[0], <unsigned> dim)))
 
     @staticmethod
     def mean(x, dim = None):
         cdef vector[CppTensor] xs
-        cdef _Tensor t
+        cdef Tensor t
         if isinstance(x, list):
             for t in x:
                 xs.push_back(t.wrapped[0])
-            return _Tensor.get_wrapper_with_new(new CppTensor(Tensor_mean_container(xs)))
+            return Tensor.get_wrapper_with_new(new CppTensor(Tensor_mean_container(xs)))
         else:
-            return _Tensor.get_wrapper_with_new(new CppTensor(Tensor_mean((<_Tensor> x).wrapped[0], <unsigned> dim)))
+            return Tensor.get_wrapper_with_new(new CppTensor(Tensor_mean((<Tensor> x).wrapped[0], <unsigned> dim)))
 
     @staticmethod
-    def broadcast(_Tensor x, unsigned dim, unsigned size):
-        return _Tensor.get_wrapper_with_new(new CppTensor(op_broadcast(x.wrapped[0], dim, size)))
+    def broadcast(Tensor x, unsigned dim, unsigned size):
+        return Tensor.get_wrapper_with_new(new CppTensor(op_broadcast(x.wrapped[0], dim, size)))
 
     @staticmethod
-    def logsumexp(_Tensor x, unsigned dim):
-        return _Tensor.get_wrapper_with_new(new CppTensor(op_logsumexp(x.wrapped[0], dim)))
+    def logsumexp(Tensor x, unsigned dim):
+        return Tensor.get_wrapper_with_new(new CppTensor(op_logsumexp(x.wrapped[0], dim)))
 
     @staticmethod
-    def log_softmax(_Tensor x, unsigned dim):
-        return _Tensor.get_wrapper_with_new(new CppTensor(op_log_softmax(x.wrapped[0], dim)))
+    def log_softmax(Tensor x, unsigned dim):
+        return Tensor.get_wrapper_with_new(new CppTensor(op_log_softmax(x.wrapped[0], dim)))
 
     @staticmethod
-    def softmax(_Tensor x, unsigned dim):
-        return _Tensor.get_wrapper_with_new(new CppTensor(op_softmax(x.wrapped[0], dim)))
+    def softmax(Tensor x, unsigned dim):
+        return Tensor.get_wrapper_with_new(new CppTensor(op_softmax(x.wrapped[0], dim)))
 
     @staticmethod
-    def softmax_cross_entropy(_Tensor x, t, unsigned dim):
-        if isinstance(t, _Tensor):
-            return _Tensor.get_wrapper_with_new(new CppTensor(op_softmax_cross_entropy(x.wrapped[0], (<_Tensor> t).wrapped[0], dim)))
+    def softmax_cross_entropy(Tensor x, t, unsigned dim):
+        if isinstance(t, Tensor):
+            return Tensor.get_wrapper_with_new(new CppTensor(op_softmax_cross_entropy(x.wrapped[0], (<Tensor> t).wrapped[0], dim)))
         elif isinstance(t, list):
-            return _Tensor.get_wrapper_with_new(new CppTensor(op_softmax_cross_entropy(x.wrapped[0], <vector[unsigned]> t, dim)))
+            return Tensor.get_wrapper_with_new(new CppTensor(op_softmax_cross_entropy(x.wrapped[0], <vector[unsigned]> t, dim)))
         else:
             raise TypeError("`t` has incorrect type.")
 
     @staticmethod
-    def constant(shape, float k, _Device device = None):
+    def constant(shape, float k, Device device = None):
         if device is None:
-            device = _Device.get_default()
-        return _Tensor.get_wrapper_with_new(new CppTensor(op_constant[CppTensor](normShape(shape).wrapped, k, device.wrapped[0])))
+            device = Device.get_default()
+        return Tensor.get_wrapper_with_new(new CppTensor(op_constant[CppTensor](normShape(shape).wrapped, k, device.wrapped[0])))
 
     @staticmethod
-    def zeros(shape, _Device device = None):
+    def zeros(shape, Device device = None):
         if device is None:
-            device = _Device.get_default()
-        return _Tensor.get_wrapper_with_new(new CppTensor(op_zeros[CppTensor](normShape(shape).wrapped, device.wrapped[0])))
+            device = Device.get_default()
+        return Tensor.get_wrapper_with_new(new CppTensor(op_zeros[CppTensor](normShape(shape).wrapped, device.wrapped[0])))
 
     @staticmethod
-    def ones(shape, _Device device = None):
+    def ones(shape, Device device = None):
         if device is None:
-            device = _Device.get_default()
-        return _Tensor.get_wrapper_with_new(new CppTensor(op_ones[CppTensor](normShape(shape).wrapped, device.wrapped[0])))
+            device = Device.get_default()
+        return Tensor.get_wrapper_with_new(new CppTensor(op_ones[CppTensor](normShape(shape).wrapped, device.wrapped[0])))
 
     @staticmethod
-    def identity(unsigned size, _Device device = None):
+    def identity(unsigned size, Device device = None):
         if device is None:
-            device = _Device.get_default()
-        return _Tensor.get_wrapper_with_new(new CppTensor(op_identity[CppTensor](size, device.wrapped[0])))
+            device = Device.get_default()
+        return Tensor.get_wrapper_with_new(new CppTensor(op_identity[CppTensor](size, device.wrapped[0])))
 
     class batch:
         @staticmethod
-        def sum(_Tensor x):
-            return _Tensor.get_wrapper_with_new(new CppTensor(op_batch_sum[CppTensor](x.wrapped[0])))
+        def sum(Tensor x):
+            return Tensor.get_wrapper_with_new(new CppTensor(op_batch_sum[CppTensor](x.wrapped[0])))
 
         @staticmethod
-        def mean(_Tensor x):
-            return _Tensor.get_wrapper_with_new(new CppTensor(op_batch_mean[CppTensor](x.wrapped[0])))
+        def mean(Tensor x):
+            return Tensor.get_wrapper_with_new(new CppTensor(op_batch_mean[CppTensor](x.wrapped[0])))
 
         @staticmethod
-        def normalize(_Tensor x):
-            return _Tensor.get_wrapper_with_new(new CppTensor(op_batch_normalize[CppTensor](x.wrapped[0])))
+        def normalize(Tensor x):
+            return Tensor.get_wrapper_with_new(new CppTensor(op_batch_normalize[CppTensor](x.wrapped[0])))
 
     class random:
         @staticmethod
-        def bernoulli(shape, float p, _Device device = None):
+        def bernoulli(shape, float p, Device device = None):
             if device is None:
-                device = _Device.get_default()
-            return _Tensor.get_wrapper_with_new(new CppTensor(op_random_bernoulli[CppTensor](normShape(shape).wrapped, p, device.wrapped[0])))
+                device = Device.get_default()
+            return Tensor.get_wrapper_with_new(new CppTensor(op_random_bernoulli[CppTensor](normShape(shape).wrapped, p, device.wrapped[0])))
 
         @staticmethod
-        def uniform(shape, float lower, float upper, _Device device = None):
+        def uniform(shape, float lower, float upper, Device device = None):
             if device is None:
-                device = _Device.get_default()
-            return _Tensor.get_wrapper_with_new(new CppTensor(op_random_uniform[CppTensor](normShape(shape).wrapped, lower, upper, device.wrapped[0])))
+                device = Device.get_default()
+            return Tensor.get_wrapper_with_new(new CppTensor(op_random_uniform[CppTensor](normShape(shape).wrapped, lower, upper, device.wrapped[0])))
 
         @staticmethod
-        def normal(shape, float mean, float sd, _Device device = None):
+        def normal(shape, float mean, float sd, Device device = None):
             if device is None:
-                device = _Device.get_default()
-            return _Tensor.get_wrapper_with_new(new CppTensor(op_random_normal[CppTensor](normShape(shape).wrapped, mean, sd, device.wrapped[0])))
+                device = Device.get_default()
+            return Tensor.get_wrapper_with_new(new CppTensor(op_random_normal[CppTensor](normShape(shape).wrapped, mean, sd, device.wrapped[0])))
 
         @staticmethod
-        def log_normal(shape, float mean, float sd, _Device device = None):
+        def log_normal(shape, float mean, float sd, Device device = None):
             if device is None:
-                device = _Device.get_default()
-            return _Tensor.get_wrapper_with_new(new CppTensor(op_random_log_normal[CppTensor](normShape(shape).wrapped, mean, sd, device.wrapped[0])))
+                device = Device.get_default()
+            return Tensor.get_wrapper_with_new(new CppTensor(op_random_log_normal[CppTensor](normShape(shape).wrapped, mean, sd, device.wrapped[0])))
 
         @staticmethod
-        def gumbel(shape, float mu, float beta, _Device device = None):
+        def gumbel(shape, float mu, float beta, Device device = None):
             if device is None:
-                device = _Device.get_default()
-            return _Tensor.get_wrapper_with_new(new CppTensor(op_random_gumbel[CppTensor](normShape(shape).wrapped, mu, beta, device.wrapped[0])))
+                device = Device.get_default()
+            return Tensor.get_wrapper_with_new(new CppTensor(op_random_gumbel[CppTensor](normShape(shape).wrapped, mu, beta, device.wrapped[0])))
 
     @staticmethod
-    def dropout(_Tensor x, float rate, bool enabled):
-        return _Tensor.get_wrapper_with_new(new CppTensor(op_dropout(x.wrapped[0], rate, enabled)))
+    def dropout(Tensor x, float rate, bool enabled):
+        return Tensor.get_wrapper_with_new(new CppTensor(op_dropout(x.wrapped[0], rate, enabled)))

--- a/python-primitiv/primitiv/_optimizer.pxd
+++ b/python-primitiv/primitiv/_optimizer.pxd
@@ -6,7 +6,7 @@ from libcpp.memory cimport shared_ptr
 
 from primitiv._device cimport CppDevice
 from primitiv._model cimport CppModel
-from primitiv._parameter cimport CppParameter, _Parameter
+from primitiv._parameter cimport CppParameter, Parameter
 from primitiv._shape cimport CppShape
 
 
@@ -32,7 +32,7 @@ cdef extern from "primitiv/optimizer.h":
         void set_configs(const unordered_map[string, unsigned] &uint_configs, const unordered_map[string, float] &float_configs) except +
 
 
-cdef class _Optimizer:
+cdef class Optimizer:
     cdef CppOptimizer *wrapped
 
 

--- a/python-primitiv/primitiv/_optimizer.pyx
+++ b/python-primitiv/primitiv/_optimizer.pyx
@@ -1,9 +1,9 @@
-from primitiv._model cimport _Model
-from primitiv._parameter cimport _Parameter
+from primitiv._model cimport Model
+from primitiv._parameter cimport Parameter
 from primitiv.config cimport pystr_to_cppstr, cppstr_to_pystr
 
 
-cdef class _Optimizer:
+cdef class Optimizer:
     """Abstract class for parameter optimizers.
 
     """
@@ -141,7 +141,7 @@ cdef class _Optimizer:
         self.wrapped.set_gradient_clipping(threshold)
         return
 
-    def add_parameter(self, _Parameter param):
+    def add_parameter(self, Parameter param):
         """Registers a parameter.
 
         :param param: Parameter to be optimized.
@@ -151,7 +151,7 @@ cdef class _Optimizer:
         self.wrapped.add_parameter(param.wrapped[0])
         return
 
-    def add_model(self, _Model model):
+    def add_model(self, Model model):
         """Registers all trainable parameters in a model.
 
         :param model: Model to be optimized.
@@ -215,7 +215,7 @@ cdef public api int python_primitiv_optimizer_configure_parameter(
     # `hasattr(self.__class__, "configure_parameter")` also scans a parent class.
     # We want check that the function is overrided or not.
     if "configure_parameter" in self.__class__.__dict__ and callable(self.configure_parameter):
-        self.configure_parameter(_Parameter.get_wrapper(&param))
+        self.configure_parameter(Parameter.get_wrapper(&param))
         return 0
     raise NotImplementedError("'configure_parameter()' is not implemented in '%s'"
                                         % self.__class__.__name__)
@@ -229,7 +229,7 @@ cdef public api int python_primitiv_optimizer_update_parameter(
     # `hasattr(self.__class__, "update_parameter")` also scans a parent class.
     # We want check that the function is overrided or not.
     if "update_parameter" in self.__class__.__dict__ and callable(self.update_parameter):
-        self.update_parameter(scale, _Parameter.get_wrapper(&param))
+        self.update_parameter(scale, Parameter.get_wrapper(&param))
         return 0
     raise NotImplementedError("'update_parameter()' is not implemented in '%s'"
                                         % self.__class__.__name__)

--- a/python-primitiv/primitiv/_parameter.pxd
+++ b/python-primitiv/primitiv/_parameter.pxd
@@ -3,10 +3,10 @@ from libcpp.string cimport string
 from libcpp cimport bool
 from libc.stdint cimport uintptr_t
 
-from primitiv._tensor cimport CppTensor, _Tensor
-from primitiv._shape cimport CppShape, _Shape
+from primitiv._tensor cimport CppTensor, Tensor
+from primitiv._shape cimport CppShape, Shape
 from primitiv._device cimport CppDevice
-from primitiv._initializer cimport CppInitializer, _Initializer
+from primitiv._initializer cimport CppInitializer, Initializer
 
 
 cdef extern from "primitiv/parameter.h":
@@ -29,24 +29,24 @@ cdef extern from "primitiv/parameter.h":
         CppTensor &stats(const string &name) except +
 
 
-cdef class _ParameterStatistics:
+cdef class ParameterStatistics:
     cdef object param_ref
 
 
-cdef class _Parameter:
+cdef class Parameter:
     cdef CppParameter *wrapped
     cdef object __weakref__
-    cdef readonly _ParameterStatistics stats
+    cdef readonly ParameterStatistics stats
     """A dictionary-like object of the current opotional statistics.
 
     """
     @staticmethod
-    cdef void register_wrapper(CppParameter *ptr, _Parameter wrapper)
+    cdef void register_wrapper(CppParameter *ptr, Parameter wrapper)
     @staticmethod
-    cdef _Parameter get_wrapper(CppParameter *ptr)
+    cdef Parameter get_wrapper(CppParameter *ptr)
     @staticmethod
-    cdef _Parameter get_wrapper_with_new(CppParameter *ptr)
+    cdef Parameter get_wrapper_with_new(CppParameter *ptr)
 
     # NOTE(vbkaisetsu)
-    # _Parameter is always created with `new`, so `del_required` is not used.
+    # Parameter is always created with `new`, so `del_required` is not used.
     # cdef bool del_required

--- a/python-primitiv/primitiv/_shape.pxd
+++ b/python-primitiv/primitiv/_shape.pxd
@@ -30,17 +30,17 @@ cdef extern from "primitiv/shape.h":
         void update_batch(unsigned batch) except +
 
 
-cdef class _Shape:
+cdef class Shape:
     cdef CppShape wrapped
 
 
-cdef inline _Shape wrapShape(CppShape wrapped) except +:
-    cdef _Shape shape = _Shape.__new__(_Shape)
+cdef inline Shape wrapShape(CppShape wrapped) except +:
+    cdef Shape shape = Shape.__new__(Shape)
     shape.wrapped = wrapped
     return shape
 
-cdef inline _Shape normShape(shapelike):
-    if isinstance(shapelike, _Shape):
+cdef inline Shape normShape(shapelike):
+    if isinstance(shapelike, Shape):
         return shapelike
     else:
-        return _Shape(shapelike)
+        return Shape(shapelike)

--- a/python-primitiv/primitiv/_shape.pyx
+++ b/python-primitiv/primitiv/_shape.pyx
@@ -2,7 +2,7 @@ from libcpp.vector cimport vector
 from primitiv.config cimport cppstr_to_pystr
 
 
-cdef class _Shape:
+cdef class Shape:
     """Data structure to represent the shape of the node.
 
     Examples:
@@ -96,10 +96,10 @@ cdef class _Shape:
     def __getitem__(self, unsigned i):
         return self.wrapped[i]
 
-    def __eq__(_Shape self, _Shape rhs):
+    def __eq__(Shape self, Shape rhs):
         return self.wrapped == rhs.wrapped
 
-    def __ne__(_Shape self, _Shape rhs):
+    def __ne__(Shape self, Shape rhs):
         return self.wrapped != rhs.wrapped
 
     def has_batch(self):
@@ -111,7 +111,7 @@ cdef class _Shape:
         """
         return self.wrapped.has_batch()
 
-    def has_compatible_batch(self, _Shape rhs):
+    def has_compatible_batch(self, Shape rhs):
         """Checks whether two batch size is compatible (broadcastable) or not.
 
         :param rhs: Shape object to compare.
@@ -149,7 +149,7 @@ cdef class _Shape:
         """
         return self.wrapped.is_matrix()
 
-    def has_same_dims(self, _Shape rhs):
+    def has_same_dims(self, Shape rhs):
         """Checks whether two shapes have completely same dimensions.
 
         :param rhs: Shape object to compare.
@@ -160,7 +160,7 @@ cdef class _Shape:
         """
         return self.wrapped.has_same_dims(rhs.wrapped)
 
-    def has_same_loo_dims(self, _Shape rhs, unsigned dim):
+    def has_same_loo_dims(self, Shape rhs, unsigned dim):
         """Checks whether two shapes have same dimensions without an axis.
         (LOO: leave one out)
 

--- a/python-primitiv/primitiv/_tensor.pxd
+++ b/python-primitiv/primitiv/_tensor.pxd
@@ -44,13 +44,13 @@ cdef extern from "tensor_op.h" namespace "python_primitiv_tensor":
     cdef void op_tensor_isub(CppTensor &tensor, const CppTensor &x) except +
 
 
-cdef class _Tensor:
+cdef class Tensor:
     cdef CppTensor *wrapped
     cdef bool del_required
     cdef object __weakref__
     @staticmethod
-    cdef void register_wrapper(CppTensor *ptr, _Tensor wrapper)
+    cdef void register_wrapper(CppTensor *ptr, Tensor wrapper)
     @staticmethod
-    cdef _Tensor get_wrapper(CppTensor *ptr)
+    cdef Tensor get_wrapper(CppTensor *ptr)
     @staticmethod
-    cdef _Tensor get_wrapper_with_new(CppTensor *ptr)
+    cdef Tensor get_wrapper_with_new(CppTensor *ptr)

--- a/python-primitiv/primitiv/_tensor.pyx
+++ b/python-primitiv/primitiv/_tensor.pyx
@@ -1,8 +1,8 @@
 from libc.stdint cimport uintptr_t
 from libcpp.vector cimport vector
 
-from primitiv._device cimport _Device
-from primitiv._shape cimport _Shape, wrapShape, normShape
+from primitiv._device cimport Device
+from primitiv._shape cimport Shape, wrapShape, normShape
 from primitiv._operator cimport op_pow, op_ipow, op_matmul
 
 from weakref import WeakValueDictionary
@@ -18,12 +18,12 @@ import numpy as np
 cdef object py_primitiv_tensor_weak_dict = WeakValueDictionary()
 
 
-cdef class _Tensor:
+cdef class Tensor:
     """Value with any dimensions.
 
     """
 
-    def __init__(self, _Tensor src = None):
+    def __init__(self, Tensor src = None):
         if self.wrapped is not NULL:
             raise TypeError("__init__() has already been called.")
         if src is None:
@@ -31,7 +31,7 @@ cdef class _Tensor:
         else:
             self.wrapped = new CppTensor(src.wrapped[0])
         self.del_required = True
-        _Tensor.register_wrapper(self.wrapped, self)
+        Tensor.register_wrapper(self.wrapped, self)
 
     def __dealloc__(self):
         if self.del_required:
@@ -66,7 +66,7 @@ cdef class _Tensor:
         :rtype: primitiv.Device
 
         """
-        return _Device.get_wrapper(&self.wrapped.device())
+        return Device.get_wrapper(&self.wrapped.device())
 
     #def data(self):
         #return self.wrapped.data()
@@ -180,7 +180,7 @@ cdef class _Tensor:
         """
         self.wrapped.reset_by_vector(values)
 
-    def reshape(self, _Shape new_shape):
+    def reshape(self, Shape new_shape):
         """Returns a tensor which have the same values and different shape.
 
         :param new_shape: New shape with batch size 1.
@@ -189,7 +189,7 @@ cdef class _Tensor:
         :rtype: primitiv.Tensor
 
         """
-        return _Tensor.get_wrapper_with_new(new CppTensor(self.wrapped.reshape(normShape(new_shape).wrapped)))
+        return Tensor.get_wrapper_with_new(new CppTensor(self.wrapped.reshape(normShape(new_shape).wrapped)))
 
     def flatten(self):
         """Returns a flattened tensor.
@@ -198,57 +198,57 @@ cdef class _Tensor:
         :rtype: primitiv.Tensor
 
         """
-        return _Tensor.get_wrapper_with_new(new CppTensor(self.wrapped.flatten()))
+        return Tensor.get_wrapper_with_new(new CppTensor(self.wrapped.flatten()))
 
     def __pos__(self):
-        return _Tensor.get_wrapper_with_new(new CppTensor(op_tensor_pos(self.wrapped[0])))
+        return Tensor.get_wrapper_with_new(new CppTensor(op_tensor_pos(self.wrapped[0])))
 
     def __neg__(self):
-        return _Tensor.get_wrapper_with_new(new CppTensor(op_tensor_neg(self.wrapped[0])))
+        return Tensor.get_wrapper_with_new(new CppTensor(op_tensor_neg(self.wrapped[0])))
 
     def __add__(left, right):
         if isinstance(right, (int, float)):
-            return _Tensor.get_wrapper_with_new(new CppTensor(op_tensor_add((<_Tensor> left).wrapped[0], <float> right)))
+            return Tensor.get_wrapper_with_new(new CppTensor(op_tensor_add((<Tensor> left).wrapped[0], <float> right)))
         elif isinstance(left, (int, float)):
-            return _Tensor.get_wrapper_with_new(new CppTensor(op_tensor_add(<float> left, (<_Tensor> right).wrapped[0])))
-        elif isinstance(left, _Tensor) and isinstance(right, _Tensor):
-            return _Tensor.get_wrapper_with_new(new CppTensor(op_tensor_add((<_Tensor> left).wrapped[0], (<_Tensor> right).wrapped[0])))
+            return Tensor.get_wrapper_with_new(new CppTensor(op_tensor_add(<float> left, (<Tensor> right).wrapped[0])))
+        elif isinstance(left, Tensor) and isinstance(right, Tensor):
+            return Tensor.get_wrapper_with_new(new CppTensor(op_tensor_add((<Tensor> left).wrapped[0], (<Tensor> right).wrapped[0])))
         else:
             return NotImplemented
 
     def __sub__(left, right):
         if isinstance(right, (int, float)):
-            return _Tensor.get_wrapper_with_new(new CppTensor(op_tensor_sub((<_Tensor> left).wrapped[0], <float> right)))
+            return Tensor.get_wrapper_with_new(new CppTensor(op_tensor_sub((<Tensor> left).wrapped[0], <float> right)))
         elif isinstance(left, (int, float)):
-            return _Tensor.get_wrapper_with_new(new CppTensor(op_tensor_sub(<float> left, (<_Tensor> right).wrapped[0])))
-        elif isinstance(left, _Tensor) and isinstance(right, _Tensor):
-            return _Tensor.get_wrapper_with_new(new CppTensor(op_tensor_sub((<_Tensor> left).wrapped[0], (<_Tensor> right).wrapped[0])))
+            return Tensor.get_wrapper_with_new(new CppTensor(op_tensor_sub(<float> left, (<Tensor> right).wrapped[0])))
+        elif isinstance(left, Tensor) and isinstance(right, Tensor):
+            return Tensor.get_wrapper_with_new(new CppTensor(op_tensor_sub((<Tensor> left).wrapped[0], (<Tensor> right).wrapped[0])))
         else:
             return NotImplemented
 
     def __mul__(left, right):
         if isinstance(right, (int, float)):
-            return _Tensor.get_wrapper_with_new(new CppTensor(op_tensor_mul((<_Tensor> left).wrapped[0], <float> right)))
+            return Tensor.get_wrapper_with_new(new CppTensor(op_tensor_mul((<Tensor> left).wrapped[0], <float> right)))
         elif isinstance(left, (int, float)):
-            return _Tensor.get_wrapper_with_new(new CppTensor(op_tensor_mul(<float> left, (<_Tensor> right).wrapped[0])))
-        elif isinstance(left, _Tensor) and isinstance(right, _Tensor):
-            return _Tensor.get_wrapper_with_new(new CppTensor(op_tensor_mul((<_Tensor> left).wrapped[0], (<_Tensor> right).wrapped[0])))
+            return Tensor.get_wrapper_with_new(new CppTensor(op_tensor_mul(<float> left, (<Tensor> right).wrapped[0])))
+        elif isinstance(left, Tensor) and isinstance(right, Tensor):
+            return Tensor.get_wrapper_with_new(new CppTensor(op_tensor_mul((<Tensor> left).wrapped[0], (<Tensor> right).wrapped[0])))
         else:
             return NotImplemented
 
     def __matmul__(left, right):
-        if isinstance(left, _Tensor) and isinstance(right, _Tensor):
-            return _Tensor.get_wrapper_with_new(new CppTensor(op_matmul((<_Tensor> left).wrapped[0], (<_Tensor> right).wrapped[0])))
+        if isinstance(left, Tensor) and isinstance(right, Tensor):
+            return Tensor.get_wrapper_with_new(new CppTensor(op_matmul((<Tensor> left).wrapped[0], (<Tensor> right).wrapped[0])))
         else:
             return NotImplemented
 
     def __truediv__(left, right):
         if isinstance(right, (int, float)):
-            return _Tensor.get_wrapper_with_new(new CppTensor(op_tensor_div((<_Tensor> left).wrapped[0], <float> right)))
+            return Tensor.get_wrapper_with_new(new CppTensor(op_tensor_div((<Tensor> left).wrapped[0], <float> right)))
         elif isinstance(left, (int, float)):
-            return _Tensor.get_wrapper_with_new(new CppTensor(op_tensor_div(<float> left, (<_Tensor> right).wrapped[0])))
-        elif isinstance(left, _Tensor) and isinstance(right, _Tensor):
-            return _Tensor.get_wrapper_with_new(new CppTensor(op_tensor_div((<_Tensor> left).wrapped[0], (<_Tensor> right).wrapped[0])))
+            return Tensor.get_wrapper_with_new(new CppTensor(op_tensor_div(<float> left, (<Tensor> right).wrapped[0])))
+        elif isinstance(left, Tensor) and isinstance(right, Tensor):
+            return Tensor.get_wrapper_with_new(new CppTensor(op_tensor_div((<Tensor> left).wrapped[0], (<Tensor> right).wrapped[0])))
         else:
             return NotImplemented
 
@@ -256,13 +256,13 @@ cdef class _Tensor:
         if mod is not None:
             return NotImplemented
         if isinstance(right, int) and -0x80000000 <= right <= 0x7fffffff:
-            return _Tensor.get_wrapper_with_new(new CppTensor(op_ipow((<_Tensor> left).wrapped[0], <int> right)))
+            return Tensor.get_wrapper_with_new(new CppTensor(op_ipow((<Tensor> left).wrapped[0], <int> right)))
         elif isinstance(right, (int, float)):
-            return _Tensor.get_wrapper_with_new(new CppTensor(op_pow((<_Tensor> left).wrapped[0], <float> right)))
+            return Tensor.get_wrapper_with_new(new CppTensor(op_pow((<Tensor> left).wrapped[0], <float> right)))
         elif isinstance(left, (int, float)):
-            return _Tensor.get_wrapper_with_new(new CppTensor(op_pow(<float> left, (<_Tensor> right).wrapped[0])))
-        elif isinstance(left, _Tensor) and isinstance(right, _Tensor):
-            return _Tensor.get_wrapper_with_new(new CppTensor(op_pow((<_Tensor> left).wrapped[0], (<_Tensor> right).wrapped[0])))
+            return Tensor.get_wrapper_with_new(new CppTensor(op_pow(<float> left, (<Tensor> right).wrapped[0])))
+        elif isinstance(left, Tensor) and isinstance(right, Tensor):
+            return Tensor.get_wrapper_with_new(new CppTensor(op_pow((<Tensor> left).wrapped[0], (<Tensor> right).wrapped[0])))
         else:
             return NotImplemented
 
@@ -270,11 +270,11 @@ cdef class _Tensor:
         op_tensor_imul(self.wrapped[0], k)
         return self
 
-    def __iadd__(self, _Tensor x):
+    def __iadd__(self, Tensor x):
         op_tensor_iadd(self.wrapped[0], x.wrapped[0])
         return self
 
-    def __isub__(self, _Tensor x):
+    def __isub__(self, Tensor x):
         op_tensor_isub(self.wrapped[0], x.wrapped[0])
         return self
 
@@ -285,25 +285,25 @@ cdef class _Tensor:
         raise NotImplementedError(type(self).__name__ + " does not support `__deepcopy__` for now.")
 
     @staticmethod
-    cdef void register_wrapper(CppTensor *ptr, _Tensor wrapper):
+    cdef void register_wrapper(CppTensor *ptr, Tensor wrapper):
         if <uintptr_t> ptr in py_primitiv_tensor_weak_dict:
             raise ValueError("Attempted to register the same C++ object twice.")
         py_primitiv_tensor_weak_dict[<uintptr_t> ptr] = wrapper
 
     @staticmethod
-    cdef _Tensor get_wrapper(CppTensor *ptr):
+    cdef Tensor get_wrapper(CppTensor *ptr):
         ret = py_primitiv_tensor_weak_dict.get(<uintptr_t> ptr)
         if ret:
             return ret
-        cdef _Tensor tensor = _Tensor.__new__(_Tensor)
+        cdef Tensor tensor = Tensor.__new__(Tensor)
         tensor.wrapped = ptr
         tensor.del_required = False
         py_primitiv_tensor_weak_dict[<uintptr_t> ptr] = tensor
         return tensor
 
     @staticmethod
-    cdef _Tensor get_wrapper_with_new(CppTensor *ptr):
-        cdef _Tensor tensor = _Tensor.__new__(_Tensor)
+    cdef Tensor get_wrapper_with_new(CppTensor *ptr):
+        cdef Tensor tensor = Tensor.__new__(Tensor)
         tensor.wrapped = ptr
         tensor.del_required = False  # dummy to add this to dict.
         if py_primitiv_tensor_weak_dict.setdefault(<uintptr_t> ptr, tensor) is not tensor:

--- a/python-primitiv/primitiv/devices/__init__.py
+++ b/python-primitiv/primitiv/devices/__init__.py
@@ -1,19 +1,17 @@
+from primitiv.devices._naive_device import Naive
+__all__ = ["Naive"]
+
 try:
-    from primitiv.devices._cuda_device import _CUDA as CUDA
+    from primitiv.devices._cuda_device import CUDA
+    __all__.append("CUDA")
 #except ModuleNotFoundError:
 except ImportError:
     pass
 
 try:
-    from primitiv.devices._opencl_device import _OpenCL as OpenCL
+    from primitiv.devices._opencl_device import OpenCL
+    __all__.append("OpenCL")
 #except ModuleNotFoundError:
 except ImportError:
     pass
 
-from primitiv.devices._naive_device import _Naive as Naive
-
-__all__ = [
-    "CUDA",
-    "Naive",
-    "OpenCL",
-]

--- a/python-primitiv/primitiv/devices/_cuda_device.pxd
+++ b/python-primitiv/primitiv/devices/_cuda_device.pxd
@@ -9,5 +9,5 @@ cdef extern from "primitiv/cuda_device.h":
         unsigned num_devices() except +
 
 
-cdef class _CUDA(_Device):
+cdef class CUDA(_Device):
     pass

--- a/python-primitiv/primitiv/devices/_cuda_device.pyx
+++ b/python-primitiv/primitiv/devices/_cuda_device.pyx
@@ -1,7 +1,7 @@
 from primitiv._device cimport _Device
 
 
-cdef class _CUDA(_Device):
+cdef class CUDA(_Device):
 
     def __init__(self, unsigned device_id, rng_seed = None):
         """Creates a new CUDA device.

--- a/python-primitiv/primitiv/devices/_naive_device.pxd
+++ b/python-primitiv/primitiv/devices/_naive_device.pxd
@@ -1,4 +1,4 @@
-from primitiv._device cimport CppDevice, _Device
+from primitiv._device cimport CppDevice, Device
 
 
 cdef extern from "primitiv/naive_device.h":
@@ -7,5 +7,5 @@ cdef extern from "primitiv/naive_device.h":
         CppNaive(unsigned rng_seed) except +
 
 
-cdef class _Naive(_Device):
+cdef class Naive(Device):
     pass

--- a/python-primitiv/primitiv/devices/_naive_device.pyx
+++ b/python-primitiv/primitiv/devices/_naive_device.pyx
@@ -1,7 +1,7 @@
-from primitiv._device cimport _Device
+from primitiv._device cimport Device
 
 
-cdef class _Naive(_Device):
+cdef class Naive(Device):
     """Creates a Naive object.
 
     """
@@ -20,7 +20,7 @@ cdef class _Naive(_Device):
         else:
             self.wrapped = new CppNaive(<unsigned> rng_seed)
 
-        _Device.register_wrapper(self.wrapped, self)
+        Device.register_wrapper(self.wrapped, self)
 
     def __dealloc__(self):
         if self.wrapped is not NULL:

--- a/python-primitiv/primitiv/devices/_opencl_device.pxd
+++ b/python-primitiv/primitiv/devices/_opencl_device.pxd
@@ -1,4 +1,4 @@
-from primitiv._device cimport CppDevice, _Device
+from primitiv._device cimport CppDevice, Device
 
 
 cdef extern from "primitiv/opencl_device.h":
@@ -11,5 +11,5 @@ cdef extern from "primitiv/opencl_device.h":
         unsigned num_devices(unsigned platform_id) except +
 
 
-cdef class _OpenCL(_Device):
+cdef class OpenCL(Device):
     pass

--- a/python-primitiv/primitiv/devices/_opencl_device.pyx
+++ b/python-primitiv/primitiv/devices/_opencl_device.pyx
@@ -1,7 +1,7 @@
-from primitiv._device cimport _Device
+from primitiv._device cimport Device
 
 
-cdef class _OpenCL(_Device):
+cdef class OpenCL(Device):
 
     def __init__(self, unsigned platform_id, unsigned device_id, rng_seed=None):
         """Creates a new OpenCL device.
@@ -21,7 +21,7 @@ cdef class _OpenCL(_Device):
         else:
             self.wrapped = new CppOpenCL(platform_id, device_id, <unsigned> rng_seed)
 
-        _Device.register_wrapper(self.wrapped, self)
+        Device.register_wrapper(self.wrapped, self)
 
     def __dealloc__(self):
         if self.wrapped is not NULL:

--- a/python-primitiv/primitiv/initializers/__init__.py
+++ b/python-primitiv/primitiv/initializers/__init__.py
@@ -1,9 +1,9 @@
-from primitiv.initializers._initializer_impl import _Constant as Constant
-from primitiv.initializers._initializer_impl import _Uniform as Uniform
-from primitiv.initializers._initializer_impl import _Normal as Normal
-from primitiv.initializers._initializer_impl import _Identity as Identity
-from primitiv.initializers._initializer_impl import _XavierUniform as XavierUniform
-from primitiv.initializers._initializer_impl import _XavierNormal as XavierNormal
+from primitiv.initializers._initializer_impl import Constant
+from primitiv.initializers._initializer_impl import Uniform
+from primitiv.initializers._initializer_impl import Normal
+from primitiv.initializers._initializer_impl import Identity
+from primitiv.initializers._initializer_impl import XavierUniform
+from primitiv.initializers._initializer_impl import XavierNormal
 
 __all__ = [
     "Constant",

--- a/python-primitiv/primitiv/initializers/_initializer_impl.pxd
+++ b/python-primitiv/primitiv/initializers/_initializer_impl.pxd
@@ -1,4 +1,4 @@
-from primitiv._initializer cimport CppInitializer, _Initializer
+from primitiv._initializer cimport CppInitializer, Initializer
 
 
 cdef extern from "primitiv/initializer_impl.h":
@@ -21,20 +21,20 @@ cdef extern from "primitiv/initializer_impl.h":
         CppXavierNormal(float scale)
 
 
-cdef class _Constant(_Initializer):
+cdef class Constant(Initializer):
     pass
 
-cdef class _Uniform(_Initializer):
+cdef class Uniform(Initializer):
     pass
 
-cdef class _Normal(_Initializer):
+cdef class Normal(Initializer):
     pass
 
-cdef class _Identity(_Initializer):
+cdef class Identity(Initializer):
     pass
 
-cdef class _XavierUniform(_Initializer):
+cdef class XavierUniform(Initializer):
     pass
 
-cdef class _XavierNormal(_Initializer):
+cdef class XavierNormal(Initializer):
     pass

--- a/python-primitiv/primitiv/initializers/_initializer_impl.pyx
+++ b/python-primitiv/primitiv/initializers/_initializer_impl.pyx
@@ -1,4 +1,4 @@
-cdef class _Constant(_Initializer):
+cdef class Constant(Initializer):
     """Initializer to generate a same-value tensor.
 
     """
@@ -23,7 +23,7 @@ cdef class _Constant(_Initializer):
             self.wrapped_newed = NULL
 
 
-cdef class _Uniform(_Initializer):
+cdef class Uniform(Initializer):
     """Initializer using a parameterized uniform distribution (lower, upper].
 
     """
@@ -50,7 +50,7 @@ cdef class _Uniform(_Initializer):
             self.wrapped_newed = NULL
 
 
-cdef class _Normal(_Initializer):
+cdef class Normal(Initializer):
     """Initializer using a parameterized normal distribution N(mean, sd).
 
     """
@@ -77,7 +77,7 @@ cdef class _Normal(_Initializer):
             self.wrapped_newed = NULL
 
 
-cdef class _Identity(_Initializer):
+cdef class Identity(Initializer):
     """Identity matrix initializer.
 
     """
@@ -99,7 +99,7 @@ cdef class _Identity(_Initializer):
             self.wrapped_newed = NULL
 
 
-cdef class _XavierUniform(_Initializer):
+cdef class XavierUniform(Initializer):
     """The Xavier matrix initialization with the uniform distribution.
 
     """
@@ -124,7 +124,7 @@ cdef class _XavierUniform(_Initializer):
             self.wrapped_newed = NULL
 
 
-cdef class _XavierNormal(_Initializer):
+cdef class XavierNormal(Initializer):
     """The Xavier matrix initialization with the normal distribution.
 
     """

--- a/python-primitiv/primitiv/optimizers/__init__.py
+++ b/python-primitiv/primitiv/optimizers/__init__.py
@@ -1,9 +1,9 @@
-from primitiv.optimizers._optimizer_impl import _SGD as SGD
-from primitiv.optimizers._optimizer_impl import _MomentumSGD as MomentumSGD
-from primitiv.optimizers._optimizer_impl import _AdaGrad as AdaGrad
-from primitiv.optimizers._optimizer_impl import _RMSProp as RMSProp
-from primitiv.optimizers._optimizer_impl import _AdaDelta as AdaDelta
-from primitiv.optimizers._optimizer_impl import _Adam as Adam
+from primitiv.optimizers._optimizer_impl import SGD
+from primitiv.optimizers._optimizer_impl import MomentumSGD
+from primitiv.optimizers._optimizer_impl import AdaGrad
+from primitiv.optimizers._optimizer_impl import RMSProp
+from primitiv.optimizers._optimizer_impl import AdaDelta
+from primitiv.optimizers._optimizer_impl import Adam
 
 __all__ = [
     "SGD",

--- a/python-primitiv/primitiv/optimizers/_optimizer_impl.pxd
+++ b/python-primitiv/primitiv/optimizers/_optimizer_impl.pxd
@@ -2,7 +2,7 @@ from libcpp.string cimport string
 from libcpp.unordered_map cimport unordered_map
 
 from primitiv._device cimport CppDevice
-from primitiv._optimizer cimport CppOptimizer, _Optimizer
+from primitiv._optimizer cimport CppOptimizer, Optimizer
 
 
 cdef extern from "primitiv/optimizer_impl.h":
@@ -39,25 +39,25 @@ cdef extern from "primitiv/optimizer_impl.h":
         float eps()
 
 
-cdef class _SGD(_Optimizer):
+cdef class SGD(Optimizer):
     pass
 
 
-cdef class _MomentumSGD(_Optimizer):
+cdef class MomentumSGD(Optimizer):
     pass
 
 
-cdef class _AdaGrad(_Optimizer):
+cdef class AdaGrad(Optimizer):
     pass
 
 
-cdef class _RMSProp(_Optimizer):
+cdef class RMSProp(Optimizer):
     pass
 
 
-cdef class _AdaDelta(_Optimizer):
+cdef class AdaDelta(Optimizer):
     pass
 
 
-cdef class _Adam(_Optimizer):
+cdef class Adam(Optimizer):
     pass

--- a/python-primitiv/primitiv/optimizers/_optimizer_impl.pyx
+++ b/python-primitiv/primitiv/optimizers/_optimizer_impl.pyx
@@ -1,7 +1,7 @@
 from libcpp.string cimport string
 
 
-cdef class _SGD(_Optimizer):
+cdef class SGD(Optimizer):
     """Simple stochastic gradient descent.
 
     """
@@ -27,7 +27,7 @@ cdef class _SGD(_Optimizer):
         return (<CppSGD*> self.wrapped).eta()
 
 
-cdef class _MomentumSGD(_Optimizer):
+cdef class MomentumSGD(Optimizer):
     """Stochastic gradient descent with momentum.
 
     """
@@ -64,7 +64,7 @@ cdef class _MomentumSGD(_Optimizer):
         return (<CppMomentumSGD*> self.wrapped).momentum()
 
 
-cdef class _AdaGrad(_Optimizer):
+cdef class AdaGrad(Optimizer):
     """AdaGrad optimizer.
 
     """
@@ -101,7 +101,7 @@ cdef class _AdaGrad(_Optimizer):
         return (<CppAdaGrad*> self.wrapped).eps()
 
 
-cdef class _RMSProp(_Optimizer):
+cdef class RMSProp(Optimizer):
     """RMSProp Optimizer.
 
     """
@@ -149,7 +149,7 @@ cdef class _RMSProp(_Optimizer):
         return (<CppRMSProp*> self.wrapped).eps()
 
 
-cdef class _AdaDelta(_Optimizer):
+cdef class AdaDelta(Optimizer):
     """AdaDelta optimizer.
     https://arxiv.org/abs/1212.5701
 
@@ -187,7 +187,7 @@ cdef class _AdaDelta(_Optimizer):
         return (<CppAdaDelta*> self.wrapped).eps()
 
 
-cdef class _Adam(_Optimizer):
+cdef class Adam(Optimizer):
     """Adam optimizer.
     https://arxiv.org/abs/1412.6980
 

--- a/python-primitiv/primitiv/utils.pxd
+++ b/python-primitiv/primitiv/utils.pxd
@@ -1,10 +1,9 @@
 from libcpp.vector cimport vector
 from libcpp cimport bool
 
-from primitiv._device cimport _Device
-from primitiv._shape cimport _Shape, normShape
-from primitiv._graph cimport _Graph, wrapNode, CppNode, _Node
-from primitiv._parameter cimport _Parameter
+from primitiv._shape cimport Shape, normShape
+from primitiv._graph cimport Graph, wrapNode, CppNode, Node
+from primitiv._parameter cimport Parameter
 
 cimport numpy as np
 import numpy as np

--- a/python-primitiv/tests/parameter.py
+++ b/python-primitiv/tests/parameter.py
@@ -3,7 +3,7 @@ from primitiv import initializers as I
 from primitiv import devices as D
 from primitiv import operators as F
 from primitiv import tensor_operators as tF
-from primitiv._parameter import _ParameterStatistics
+from primitiv._parameter import ParameterStatistics
 
 import unittest
 
@@ -43,7 +43,7 @@ class ParameterTest(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             del self.p.stats["stat1"]
         with self.assertRaises(AttributeError):
-            self.p.stats = _ParameterStatistics(self.p)
+            self.p.stats = ParameterStatistics(self.p)
 
     def test_parameter_value(self):
         self.assertTrue((self.p.value.to_ndarrays() == np.array([1, 2, 3, 4, 5, 6, 7, 8])).all())


### PR DESCRIPTION
This branch removes prefix `_` from class names in Python frontend.
It is mainly for the sphinx. This rename hides alias (e.g. `primitiv.Device` → `primitiv._device._Device`) and the documentation will be generated as expected.